### PR TITLE
Security Review — 2026-04-03 (security-warning)

### DIFF
--- a/docs/security-reports/2026-04-03.md
+++ b/docs/security-reports/2026-04-03.md
@@ -1,0 +1,230 @@
+# Security Review — 2026-04-03
+
+## 1. Dependency Vulnerability Check
+
+### Versions Audited
+
+| Package | Version | Status |
+|---------|---------|--------|
+| fastapi | 0.128.1 | OK — CVE-2026-2978/2979 affect FastApiAdmin, not FastAPI core |
+| uvicorn | 0.40.0 | OK — no recent CVEs |
+| pymongo | 4.16.0 | OK — CVE-2025-14847 affects MongoDB Server, not the driver |
+| pydantic | 2.12.5 | OK — no core library CVEs in 2025–2026 |
+| python-jose | 3.5.0 | **WARNING** — abandoned/deprecated, see finding below |
+| cryptography | 46.0.5 | **VULNERABLE** — CVE-2026-34073, see finding below |
+| anthropic | 0.77.1 | **VULNERABLE** — CVE-2026-34450, CVE-2026-34452, see finding below |
+| pillow | 12.1.1 | OK — CVE-2026-25990 patched in this version |
+| httpx | 0.28.1 | OK — no recent CVEs |
+| jinja2 | 3.1.6 | OK — CVE-2025-27516 patched in this version |
+| python-multipart | 0.0.22 | OK — CVE-2026-24486 patched in this version |
+| slowapi | 0.1.9 | OK — no known CVEs |
+| openpyxl | 3.1.5 | OK — no recent CVEs |
+
+---
+
+## 2. Hardcoded Secrets Scan
+
+**Scanned patterns:** API keys (`sk-`, `pk_`, `phc_`, `AKIA`), connection strings (`mongodb://`, `mongodb+srv://`), passwords, private keys (`BEGIN RSA/EC/PRIVATE`), JWTs (`eyJ`).
+
+**Result:** No real secrets found in source code. All matches are:
+- Localhost default connection strings (`mongodb://localhost:27017`)
+- Documentation examples with placeholder values (`mongodb+srv://user:pass@host`)
+- Test fixtures with obvious dummy values (`sk-ant-api-key`, `AKIAIOSFODNN7EXAMPLE`)
+
+**Git-tracked sensitive files:** Only `config/secrets.env.example` (template, no real values).
+
+---
+
+## 3. Authentication & Authorization Audit
+
+**Password hashing:** Argon2id via `pwdlib` — industry best practice. ✅
+
+**Constant-time comparison:** Dummy hash used for non-existent users to prevent timing-based user enumeration (`winebox/services/auth.py:108-112`). ✅
+
+**JWT tokens:** HS256 with configurable secret key, 2-hour expiry, unique `jti` for revocation support. ✅
+
+**Token revocation:** Blacklist-based revocation via `RevokedToken` model, checked on every request (`winebox/services/auth.py:177-181`). ✅
+
+**Account lockout:** Implemented via `LoginAttempt` model with timed lockout after failed attempts (`winebox/services/auth.py:88-100`). ✅
+
+**Rate limiting on auth:** Login (`30/minute;200/hour`), password change (`5/minute;20/hour`). ✅
+
+**owner_id filtering:** Found 102 occurrences of `owner_id` across 17 router files — consistent data isolation pattern. ✅
+
+**Password change token invalidation:** Only revokes the *current session token*, not ALL tokens for the user (`winebox/routers/auth.py:171-178`). **See WARNING finding below.**
+
+---
+
+## 4. NoSQL Injection & Query Safety
+
+**Regex injection:** All user input in regex patterns uses `re.escape()` — found in `search.py`, `reference.py`, `xwines.py`, and `xwines_enrichment.py`. ✅
+
+**Dangerous operators:** No usage of `$where`, `$expr`, or `$accumulator` found anywhere in the codebase. ✅
+
+**ObjectId parsing:** Wrapped in try/except blocks. ✅
+
+**Input validation:** All API inputs use Pydantic models. ✅
+
+---
+
+## 5. Rate Limiting & DoS Prevention
+
+**Global rate limit:** 60 requests/minute via SlowAPI (`winebox/main.py:34-38`). ✅
+
+**Auth endpoint limits:** Applied on login and password change endpoints. ✅
+
+**File upload limits:** Bounded at 10 MB via `StorageConfig.max_upload_mb`. ✅
+
+**Database connection pool:** min=10, max=100 — bounded. ✅
+
+---
+
+## 6. Session & Token Security
+
+**JWT configuration:** HS256, 2-hour expiry, `jti` for revocation. ✅
+
+**Token revocation:** Implemented via `RevokedToken` blacklist model. ✅
+
+**Secret key handling:** Loaded from environment/secrets, auto-generated with warning if missing. ✅
+
+---
+
+## 7. Security Headers
+
+All responses include comprehensive security headers via `SecurityHeadersMiddleware` (`winebox/main.py:41-84`):
+
+- `X-Content-Type-Options: nosniff` ✅
+- `X-Frame-Options: DENY` ✅
+- `Content-Security-Policy` — strict policy, no `unsafe-inline` for scripts ✅
+- `Strict-Transport-Security` — enabled when `enforce_https=True` ✅
+- `Referrer-Policy: strict-origin-when-cross-origin` ✅
+- `Permissions-Policy` — restrictive ✅
+- `X-Permitted-Cross-Domain-Policies: none` ✅
+
+**CORS:** Empty by default (same-origin only), configurable via `cors_origins`. ✅
+
+---
+
+## 8. Data Exposure
+
+**User response model:** `UserResponse` in `winebox/routers/auth.py:73-85` excludes `hashed_password`. ✅
+
+**Error messages:** Generic auth errors ("Incorrect email or password"), no stack traces in responses. ✅
+
+**Debug mode:** Default `debug=False` in `ServerConfig`. ✅
+
+---
+
+## 9. Infrastructure & Configuration
+
+**Production safety:** `_check_database_safety()` prevents non-production hosts from using production database on Atlas. ✅
+
+**Secrets management:** All secrets loaded from environment variables or `secrets.env`. ✅
+
+**Anthropic API key:** Loaded from environment (`WINEBOX_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`), never hardcoded. ✅
+
+---
+
+## 10. Git History & Recent Changes
+
+**Last 30 commits reviewed:** Mostly version bumps and feature work (import dashboard, CSV import, cases). No security-concerning changes.
+
+**Recent security-relevant commits:**
+- `ddeb33f` — "Replace all inline onclick handlers with CSP-compliant event listeners" — positive security improvement.
+
+**Accidentally committed secrets:** None found. Only `config/secrets.env.example` tracked (template file).
+
+---
+
+## Findings
+
+### 🔴 CRITICAL (Immediate action required)
+
+**None.**
+
+### 🟠 WARNING (Address within 1 week)
+
+#### W1: `cryptography` 46.0.5 — CVE-2026-34073 (DNS Name Constraint Bypass)
+
+**Package:** `cryptography==46.0.5`
+**CVE:** [CVE-2026-34073](https://advisories.gitlab.com/pkg/pypi/cryptography/CVE-2026-34073/)
+**Severity:** Medium
+**Description:** Prior to 46.0.6, the package only validates DNS name constraints against Subject Alternative Names in child certificates, but fails to validate the "peer name" during each validation step. This allows a peer named `bar.example.com` to be validated against `*.example.com` even if an excluded subtree constraint forbids `bar.example.com`.
+**Fix:** Upgrade to `cryptography>=46.0.6`.
+
+#### W2: `anthropic` 0.77.1 — CVE-2026-34450 & CVE-2026-34452
+
+**Package:** `anthropic==0.77.1`
+**CVEs:**
+- [CVE-2026-34450](https://advisories.gitlab.com/pkg/pypi/anthropic/CVE-2026-34450/) — Insecure default file permissions (0o666) in local filesystem memory tool. On shared hosts, persisted agent state is world-readable.
+- [CVE-2026-34452](https://advisories.gitlab.com/pkg/pypi/anthropic/CVE-2026-34452/) — Path validation race condition in async memory tool allows symlink-based sandbox escape.
+**Fix:** Upgrade to `anthropic>=0.87.0`.
+
+#### W3: Password change does not invalidate all sessions
+
+**File:** `winebox/routers/auth.py:171-178`
+**Description:** When a user changes their password, only the current session token is revoked. Other active tokens (e.g., on other devices) remain valid until they naturally expire (2 hours). If a password is changed because of a compromised session, the attacker's token on another device would still work.
+**Recommendation:** After a password change, revoke all tokens for that user — either by maintaining a `password_changed_at` timestamp that is checked during token validation, or by revoking all tokens in the blacklist for that user_id.
+
+#### W4: `python-jose` is abandoned — migrate to `PyJWT` or `joserfc`
+
+**Package:** `python-jose==3.5.0`
+**Description:** python-jose has not received meaningful updates since 2021 and is considered abandoned. FastAPI's own documentation has moved to recommending PyJWT instead. While no active CVEs affect the current version, using an unmaintained cryptographic library is a risk. CVE-2024-33663 (algorithm confusion) affected versions up to 3.3.0 and may not be fully mitigated in all usage patterns.
+**Recommendation:** Migrate to `PyJWT` or `joserfc`. The [joserfc migration guide](https://jose.authlib.org/en/migrations/python-jose/) provides step-by-step instructions.
+
+### 🟡 INFO (Best practice recommendations)
+
+#### I1: `.gitignore` missing coverage for sensitive file types
+
+**File:** `.gitignore`
+**Description:** The `.gitignore` covers `.env` and `.env.local` but does not include `secrets.env`, `*.pem`, `*.key`, or `*.p12`. While `secrets.env` is not currently tracked, an accidental `git add secrets.env` would not be caught.
+**Recommendation:** Add the following to `.gitignore`:
+```
+secrets.env
+*.pem
+*.key
+*.p12
+*.pfx
+```
+
+#### I2: Rate limiter can be disabled via environment variable
+
+**File:** `winebox/main.py:37`
+**Description:** Setting `WINEBOX_RATE_LIMIT_DISABLED=1` disables all rate limiting. This is appropriate for CI testing but should be documented and monitored. If this variable were accidentally set in production, all rate limiting protection would be lost.
+**Recommendation:** Add a startup warning log when rate limiting is disabled in a non-test environment, or restrict the disable mechanism to only work when `debug=True`.
+
+### 🟢 CLEAN (Passed review)
+
+- **Hardcoded secrets scan:** No secrets found in source code or git history.
+- **NoSQL injection:** All user input properly escaped; no dangerous MongoDB operators used.
+- **Input validation:** All API inputs use Pydantic models.
+- **Regex injection:** `re.escape()` used consistently for user input in regex patterns.
+- **Security headers:** Comprehensive CSP, HSTS, X-Frame-Options, etc.
+- **CORS configuration:** Empty by default (same-origin only).
+- **Data isolation:** `owner_id` filtering applied consistently across all user-data endpoints.
+- **Account lockout:** Implemented with timed lockout after failed login attempts.
+- **Constant-time auth:** Dummy hash comparison prevents timing-based user enumeration.
+- **Token revocation:** JWT blacklisting with `jti` support.
+- **Production safety:** Database safety check prevents non-production hosts from using production DB.
+- **File upload size limits:** Bounded at 10 MB.
+- **Connection pooling:** Bounded (min=10, max=100).
+- **Debug mode:** Disabled by default.
+- **Git history:** No security regressions in last 30 commits.
+
+---
+
+## 📊 Summary
+
+| Metric | Value |
+|--------|-------|
+| **Date** | 2026-04-03 |
+| **Critical issues** | 0 |
+| **Warning issues** | 4 |
+| **Info issues** | 2 |
+| **Clean areas** | 15 |
+
+### Top 3 Priorities
+
+1. **Upgrade `cryptography` to >=46.0.6** — fixes DNS name constraint bypass (CVE-2026-34073)
+2. **Upgrade `anthropic` to >=0.87.0** — fixes file permission and sandbox escape vulnerabilities
+3. **Implement full token invalidation on password change** — current implementation only revokes the current session, leaving other devices active


### PR DESCRIPTION
## Summary

- **0 critical** findings
- **4 warning** findings:
  - `cryptography` 46.0.5 vulnerable to CVE-2026-34073 (DNS name constraint bypass) — upgrade to >=46.0.6
  - `anthropic` 0.77.1 vulnerable to CVE-2026-34450 & CVE-2026-34452 (file permissions, sandbox escape) — upgrade to >=0.87.0
  - Password change only revokes current session token, not all tokens for the user
  - `python-jose` is abandoned — migrate to PyJWT or joserfc
- **2 info** findings: `.gitignore` missing sensitive file patterns, rate limiter disable mechanism
- **15 clean** areas passed review

### Top 3 Priorities
1. Upgrade `cryptography` to >=46.0.6
2. Upgrade `anthropic` to >=0.87.0
3. Implement full token invalidation on password change

## Test plan
- [ ] Review full report in `docs/security-reports/2026-04-03.md`
- [ ] Verify dependency upgrade recommendations against current versions
- [ ] Assess password change token invalidation fix priority

https://claude.ai/code/session_01BmHughZdhNUB4sUKGCkUay