### PR TITLE
Fix LinkedIn image display with correct OG meta tags

### DIFF
--- a/winebox/static/index.html
+++ b/winebox/static/index.html
@@ -9,10 +9,18 @@
     <meta name="description" content="AI-powered wine cellar management. Scan wine labels with your phone, track your cellar inventory, discover tasting notes, and explore over 100,000 wines from around the world.">
     <meta property="og:title" content="WineBox - Smart Wine Cellar Management">
     <meta property="og:description" content="AI-powered wine cellar management. Scan wine labels with your phone, track your cellar inventory, discover tasting notes, and explore over 100,000 wines from around the world.">
-    <meta property="og:image" content="https://winebox.app/static/logos/og-social.png">
-    <meta property="og:url" content="https://winebox.app">
+    <meta property="og:image" content="https://booze.winebox.app/static/logos/og-social.png">
+    <meta property="og:image:width" content="2400">
+    <meta property="og:image:height" content="1254">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:url" content="https://booze.winebox.app">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="WineBox">
+    <!-- Twitter Card tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="WineBox - Smart Wine Cellar Management">
+    <meta name="twitter:description" content="AI-powered wine cellar management. Scan wine labels with your phone, track your cellar inventory, discover tasting notes, and explore over 100,000 wines.">
+    <meta name="twitter:image" content="https://booze.winebox.app/static/logos/og-social.png">
     <meta name="author" content="Joe Drumgoole">
     <title>WineBox - Wine Cellar Management</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/winebox/static/landing.html
+++ b/winebox/static/landing.html
@@ -14,6 +14,11 @@
     <meta property="og:url" content="https://winebox.app/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="WineBox">
+    <!-- Twitter Card tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="WineBox - Smart Wine Cellar Management">
+    <meta name="twitter:description" content="AI-powered wine cellar management. Scan wine labels with your phone, track your cellar inventory, discover tasting notes, and explore over 100,000 wines.">
+    <meta name="twitter:image" content="https://winebox.app/static/logos/og-social.png">
     <meta name="author" content="Joe Drumgoole">
     <title>WineBox - Smart Wine Cellar Management</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
- index.html: Fix og:image and og:url to use booze.winebox.app (the actual
  app domain) instead of winebox.app, so LinkedIn's crawler fetches images
  from the correct origin
- index.html: Add missing og:image:width, og:image:height, og:image:type
  that LinkedIn requires for reliable image rendering
- Both files: Add Twitter Card meta tags (twitter:card, twitter:title,
  twitter:description, twitter:image) for broader social media support

https://claude.ai/code/session_01LjhiogDmxxPR3sbwsm9WLz