### PR TITLE
Security Review — 2026-04-07 (security-warning)

### DIFF
--- a/docs/security-reports/2026-04-07.md
+++ b/docs/security-reports/2026-04-07.md
@@ -1,0 +1,267 @@
+# WineBox Security Review — 2026-04-07
+
+## :red_circle: CRITICAL (Immediate action required)
+
+### 1. `python-jose` is abandoned (supply chain risk)
+- **Package:** `python-jose` 3.5.0
+- **Issue:** No releases since 2021. Widely considered abandoned. FastAPI documentation has moved to recommending PyJWT. An abandoned cryptographic library will not receive patches for future vulnerabilities.
+- **Recommendation:** Replace `python-jose[cryptography]` with `PyJWT[crypto]` (near drop-in replacement).
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 2. `anthropic` SDK has 2 unpatched CVEs (below 0.87.0)
+- **Package:** `anthropic` 0.77.1 (locked)
+- **CVE-2026-34450:** Insecure default file permissions (0o666) in local filesystem memory tool, allowing local attackers on shared hosts to read persisted agent state.
+- **CVE-2026-34452:** TOCTOU race condition in memory tool path validation allowing symlink-based sandbox escape.
+- **Fix:** Bump minimum to `anthropic>=0.87.0` and update `uv.lock`.
+- **Status:** Unchanged from 2026-04-06 review.
+
+---
+
+## :orange_circle: WARNING (Address within 1 week)
+
+### 3. Password change only revokes current token, not all sessions
+- **Location:** `winebox/routers/auth.py:170-178`
+- **Issue:** When a user changes their password, only the current session token is revoked. Other active sessions (e.g., on other devices) remain valid for up to 2 hours. An attacker with a stolen token retains access after the victim changes their password.
+- **Also affects:** CLI password change (`winebox/cli/user_admin.py:172-185`) revokes no tokens at all.
+- **Recommendation:** Implement `revoke_all_tokens_for_user()` using a `password_changed_at` timestamp or per-user token generation counter.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 4. Password reset does not invalidate existing tokens
+- **Location:** `winebox/auth/users.py:90-94`
+- **Issue:** The `on_after_reset_password` callback only logs. After a forgot-password reset, all existing JWT sessions remain valid.
+- **Recommendation:** Invoke token invalidation in `on_after_reset_password`.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 5. XSS via inconsistent `escapeHtml()` in JavaScript frontend
+- **Location:** `winebox/static/js/app.js` — multiple locations
+- **Issue:** Wine data (user-supplied via label scanning, manual entry, or imports) is inserted into `innerHTML` without `escapeHtml()` in several views:
+  - Card view: wine name (line 2379), alt attribute (line 2374)
+  - Detail view: wine name (line 2531), winery (line 2533), grape_variety (line 2548), region (line 2555), sub_region (line 2562), appellation (line 2569), country (line 2576), classification (line 2583), alcohol_percentage (line 2590)
+  - Activity feed: wine name (line 1902)
+  - Transaction history: wine name (line 2823)
+- **Note:** Other views correctly use `escapeHtml()` (e.g., table view, card list view), confirming this is an inconsistency.
+- **Risk:** Primarily self-XSS today (users inject into their own data), but escalates if wine data is ever shared between users.
+- **Recommendation:** Apply `escapeHtml()` consistently to all user-supplied data rendered via `innerHTML`.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 6. FastAPI-Users auth endpoints lack explicit rate limits
+- **Location:** `winebox/routers/auth.py:42-65`
+- **Issue:** The fastapi-users login, registration, forgot-password, reset-password, and verification routers only get the global default rate limit (60/minute). The custom `/token` endpoint has a proper `30/minute;200/hour` limit. The `POST /api/auth/forgot-password` endpoint is particularly sensitive — it triggers emails and 60/min is too generous.
+- **Note:** Account lockout after failed attempts (`services/auth.py:88`) partially mitigates brute-force on login, but registration and password reset have no such protection.
+- **Recommendation:** Add explicit `@limiter.limit()` decorators to all fastapi-users auth routes.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 7. No rate limits on expensive operations (scan, search, export, demo)
+- **Location:** Multiple routers
+- **Issue:** These cost-sensitive or resource-intensive endpoints only have the global 60/min default:
+  - `/api/wines/scan` — calls Claude Vision API (real cost per call)
+  - `/api/wines/checkin` — triggers OCR + vision API calls
+  - `/api/search` — regex search on multiple fields
+  - `/api/xwines/search` — regex fallback on large dataset
+  - `/api/xwines/export` — can export up to 10,000 results
+  - `/api/export/*` — generates CSV/XLSX files with no pagination limits
+  - `/api/import/upload` — file upload and parsing
+  - `/api/demo/install` — creates 500 wines with transactions
+- **Recommendation:** Add per-endpoint rate limits, especially on `/api/wines/scan` and `/api/wines/checkin`.
+- **Status:** Unchanged from 2026-04-06 review. Added `/api/wines/checkin` and `/api/xwines/export` to the list.
+
+### 8. No MongoDB query timeouts configured
+- **Location:** `winebox/database.py:39-43`
+- **Issue:** The MongoDB client does not set `serverSelectionTimeoutMS`, `socketTimeoutMS`, or `timeoutMS`. No queries use `maxTimeMS`. A slow or hanging query blocks the event loop indefinitely.
+- **Recommendation:** Set `timeoutMS=30000` (or appropriate value) on the MongoDB client.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 9. No timeout on Anthropic API calls
+- **Location:** `winebox/services/vision.py:120`, `winebox/services/xwines_matcher.py:154`
+- **Issue:** `client.messages.create()` has no `timeout` parameter. The Anthropic SDK defaults to 10 minutes, far too long for a web request.
+- **Recommendation:** Set explicit timeout (e.g., 60 seconds) on all Anthropic API calls.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 10. X-Wines regex search loads all results into memory before paginating
+- **Location:** `winebox/routers/xwines.py:391-393`
+- **Issue:** `_regex_search` fetches ALL matching results for three separate tiers before combining and paginating in Python. A query matching thousands of records would load all into memory. Three unbounded `.to_list()` calls are executed per search request.
+- **Recommendation:** Apply `.limit()` at the database query level.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 11. Export endpoints fetch all user data without pagination limits
+- **Location:** `winebox/routers/export.py:57, 157`
+- **Issue:** `wines = await Wine.find(conditions).to_list()` and `transactions = await Transaction.find(conditions).to_list()` fetch all matching documents with no upper bound. A user with a very large cellar could trigger memory-intensive responses.
+- **Recommendation:** Add pagination or a maximum export size.
+- **Status:** New finding.
+
+---
+
+## :yellow_circle: INFO (Best practice recommendations)
+
+### 12. `.gitignore` missing coverage for `secrets.env`, `*.pem`, `*.key`, `*.p12`
+- **Location:** `.gitignore`
+- **Issue:** While `.env` is covered, `secrets.env`, `*.pem`, `*.key`, `*.p12`, and `*.pfx` are not explicitly listed. An accidental `git add` could commit sensitive files.
+- **Recommendation:** Add explicit entries for these patterns.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 13. `.playwright-mcp/` directory tracked in git, leaks server hostnames
+- **Location:** `.playwright-mcp/` (multiple YAML files)
+- **Issue:** Playwright MCP session snapshots are committed to git and contain server infrastructure details (e.g., `Server: shared.2t22cum.mongodb.net`). This directory should not be versioned.
+- **Recommendation:** Add `.playwright-mcp/` to `.gitignore` and remove from tracking.
+- **Status:** New finding.
+
+### 14. Label images served without authentication
+- **Location:** `winebox/main.py:341`
+- **Issue:** Wine label images are served as static files at `/api/images/` with no authentication. Anyone who can guess or enumerate filenames can access other users' label photos. Contrast with `/api/prices/photos/{filename}` which correctly verifies ownership.
+- **Mitigation:** Filenames are UUIDs (hard to guess), but no access control exists.
+- **Recommendation:** Consider serving images through an authenticated endpoint if label privacy matters.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 15. `skip`/`limit` parameters lack upper bounds on multiple endpoints
+- **Locations:** `winebox/routers/wines/crud.py:22`, `winebox/routers/search.py:40-41`, `winebox/routers/transactions.py:24-25`, `winebox/routers/cellar.py:23`, `winebox/routers/met.py:18`
+- **Issue:** A client could pass `limit=999999999` to force the server to serialize a very large result set. Compare with the X-Wines endpoint which properly caps at `le=50`.
+- **Recommendation:** Add `Query(le=500)` or similar to all `limit` parameters.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 16. Import file upload has no size limit
+- **Location:** `winebox/routers/import_router.py:130`
+- **Issue:** `file_bytes = await file.read()` without checking file size. A very large CSV/XLSX could exhaust server memory. Image uploads correctly validate size via `validate_upload_size()`.
+- **Recommendation:** Add size validation before reading import files.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 17. Minimum password length is only 6 characters
+- **Location:** `winebox/auth/schemas.py:10`
+- **Issue:** `MIN_PASSWORD_LENGTH = 6` with no complexity requirements. NIST 800-63B recommends minimum 8 characters.
+- **Recommendation:** Consider increasing to 8+ characters.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 18. Loose lower bounds on dependency versions
+- **`python-multipart>=0.0.6`:** CVE-2026-24486 (path traversal) was fixed in 0.0.22. Lock file resolves safely but lower bound permits vulnerable installs.
+- **`jinja2>=3.1.0`:** CVE-2025-27516 (sandbox breakout) was fixed in 3.1.6. Lock file resolves safely but lower bound permits vulnerable installs.
+- **Recommendation:** Bump minimums to `python-multipart>=0.0.22` and `jinja2>=3.1.6`.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 19. `collection` query parameter not validated against enum
+- **Location:** `winebox/routers/wines/crud.py:32`, `winebox/routers/search.py:51`
+- **Issue:** The `collection` parameter is passed directly as a string filter without validating against `WineCollection` enum values. Not injectable (string values can't become MongoDB operators) but allows arbitrary values.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 20. Path traversal not validated in `delete_image`/`get_image_path`
+- **Location:** `winebox/services/image_storage.py:177-208`
+- **Issue:** Filename argument is not sanitized for directory traversal. Mitigated by UUID generation on save and database-sourced filenames on delete.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 21. `owner_id` exposed in export/import data
+- **Location:** `winebox/routers/export.py:91`, `winebox/routers/import_router.py:766`
+- **Issue:** `wine.model_dump(mode="json")` includes `owner_id` (internal MongoDB ObjectId) in exported files.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 22. No `server_tokens off` in nginx config
+- **Location:** `deploy/nginx-winebox.conf`
+- **Issue:** Nginx version may be exposed in response headers.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 23. Inline script in `og-preview.html`
+- **Location:** `winebox/static/og-preview.html:132`
+- **Issue:** Contains an inline `<script>` block that would be blocked by CSP. This is a dev/preview utility, not user-facing.
+- **Status:** Unchanged from 2026-04-06 review.
+
+### 24. OAT nginx has no admin IP restriction
+- **Location:** `deploy/nginx-winebox-oat.conf`
+- **Issue:** Unlike production nginx config which restricts `/admin` to a specific IP, the OAT config has no such restriction. If admin routes are mounted on OAT, they are accessible from any IP.
+- **Mitigation:** OAT is a test environment, and server-side `RequireAdmin` auth still protects admin endpoints.
+- **Status:** New finding.
+
+### 25. Missing try/except on ObjectId parsing in price_tracker
+- **Location:** `winebox/routers/price_tracker.py:199, 213`
+- **Issue:** `ObjectId(capture_id)` is called without try/except for `InvalidId`. An invalid capture_id string causes a 500 error instead of a clean 404.
+- **Status:** New finding.
+
+### 26. Missing max_length on Form fields in price_tracker
+- **Location:** `winebox/routers/price_tracker.py:80-94`
+- **Issue:** Form parameters like `shop_name`, `town_city`, `state_county`, `country`, and `currency` lack `max_length` constraints. Compare with the checkin endpoint which properly constrains all Form fields.
+- **Status:** New finding.
+
+### 27. DigitalOcean API calls have no timeout
+- **Location:** `deploy/common.py` (lines 142, 161, 191, 211, 222, 232, 242, 252, 268, 286)
+- **Issue:** All `requests.get/post/put` calls in the deploy script have no `timeout` parameter. A hung connection could block deploy scripts indefinitely.
+- **Mitigation:** Deploy-time only, not runtime.
+- **Status:** New finding.
+
+### 28. Admin info endpoint exposes MongoDB hostname
+- **Location:** `admin/admin_app/routers/admin.py:35-42`
+- **Issue:** The admin info endpoint exposes the MongoDB server hostname and database name. While gated behind `RequireAdmin`, it reveals infrastructure details.
+- **Status:** New finding.
+
+---
+
+## :green_circle: CLEAN (Passed review)
+
+### Authentication & Core Security
+- All user-data endpoints require `RequireAuth` and filter by `owner_id` — no missing auth or owner scoping found
+- All admin endpoints use `RequireAdmin` (not just `RequireAuth`)
+- Password hashing uses Argon2 via `pwdlib` — industry-standard memory-hard algorithm
+- Constant-time password comparison with anti-enumeration dummy hash verification
+- Account lockout after failed login attempts with `Retry-After` header
+- JWT tokens include unique `jti` for revocation; token blacklist checked on every request
+- Startup validates secret key length >= 32 characters in production
+- Derived per-purpose secrets for reset/verification tokens
+
+### Input Validation
+- All API inputs use Pydantic models with field constraints
+- All regex patterns from user input use `re.escape()`
+- All ObjectId parsing wrapped in try/except for `InvalidId` (except price_tracker — see #25)
+- No unsafe MongoDB operators (`$expr`, `$where`, `$function`, `$accumulator`) used
+- No NoSQL injection vectors found — all queries use typed parameters, not string interpolation
+- Search query length limited to 200 characters
+- File uploads validate size, extension (allowlist), and magic bytes
+
+### Security Headers & Transport
+- Full security header suite: X-Content-Type-Options, X-Frame-Options, CSP, HSTS, Referrer-Policy, Permissions-Policy
+- No `unsafe-inline` for `script-src` in CSP
+- CORS defaults to same-origin only (empty origins list)
+- HTTPS enforced in production with HSTS preload
+- TLS 1.2+ only with strong cipher suites in nginx
+
+### Secrets Management
+- No hardcoded secrets found in codebase (only test fixtures with obvious dummy values)
+- No secrets ever committed to git history
+- API keys loaded from environment variables / secrets files
+- Secrets not logged in error messages or security events
+- `secrets.env.example` template tracked (not actual secrets)
+
+### Dependencies (resolved versions)
+- `cryptography` 46.0.5 — patched for CVE-2026-26007
+- `pillow` 12.1.1 — patched for CVE-2026-25990
+- `jinja2` 3.1.6 — patched for CVE-2025-27516
+- `python-multipart` 0.0.22 — patched for CVE-2026-24486
+- `cairosvg` 2.9.0 — patched for CVE-2026-31899
+- All other major dependencies at current versions with no known CVEs
+
+### Infrastructure
+- Production database safety guard prevents non-production hosts from connecting to production DB
+- Debug mode blocked in production via startup validation
+- No sensitive data in error messages or stack traces
+- Admin panel IP-restricted in production nginx config
+
+---
+
+## :bar_chart: Summary
+
+| Metric | Value |
+|--------|-------|
+| **Date of review** | 2026-04-07 |
+| **Critical issues** | 2 (unchanged) |
+| **Warning issues** | 9 (+1 new) |
+| **Info issues** | 17 (+6 new) |
+| **Clean areas** | 6 categories |
+
+### Comparison with 2026-04-06 Review
+
+- **Critical:** Both issues (#1 python-jose, #2 anthropic CVEs) remain open — no remediation since last review.
+- **Warning:** All 8 previous warnings remain open. 1 new warning added (#11 — export endpoints fetch all data without limits).
+- **Info:** All 11 previous info items remain open. 6 new info items added (#13 .playwright-mcp tracked, #24 OAT nginx, #25 price_tracker ObjectId, #26 price_tracker Form fields, #27 deploy timeouts, #28 admin MongoDB exposure).
+- **No regressions introduced** in recent commits.
+
+### Top 3 Priorities
+
+1. **Replace `python-jose` with `PyJWT` and bump `anthropic>=0.87.0`** — Two critical dependency issues now in their second day without remediation: an abandoned cryptographic library and two unpatched CVEs in the Anthropic SDK.
+
+2. **Implement full token invalidation on password change/reset** — Currently only the current session is revoked, leaving other sessions (potentially attacker-controlled) active for up to 2 hours. This violates the project's own CLAUDE.md security guidelines.
+
+3. **Fix inconsistent `escapeHtml()` in JavaScript frontend** — Multiple XSS vectors exist in the card view, detail view, and activity feeds where user-supplied wine data is rendered without escaping.


### PR DESCRIPTION
## Summary

Daily security audit for 2026-04-07.

- **2 critical** issues (unchanged from 2026-04-06): `python-jose` abandoned, `anthropic` SDK CVEs
- **9 warnings** (+1 new): export endpoints fetch all user data without pagination limits
- **17 info items** (+6 new): `.playwright-mcp/` tracked in git, OAT nginx missing admin IP restriction, price_tracker ObjectId/Form validation gaps, deploy script timeouts, admin MongoDB hostname exposure
- **No regressions** introduced in recent commits
- **All previous findings remain open** — no remediation since last review

### Top 3 Priorities
1. Replace `python-jose` with `PyJWT` and bump `anthropic>=0.87.0`
2. Implement full token invalidation on password change/reset
3. Fix inconsistent `escapeHtml()` in JavaScript frontend

Full report: `docs/security-reports/2026-04-07.md`

https://claude.ai/code/session_017NweuC1Gva7yzwcPNBjpc2