### PR TITLE
Security Review — 2026-04-13 security-warning

### DIFF
--- a/docs/security-reports/2026-04-13.md
+++ b/docs/security-reports/2026-04-13.md
@@ -1,0 +1,256 @@
+# WineBox Security Review — 2026-04-13
+
+## :red_circle: CRITICAL (Immediate action required)
+
+### 1. `python-jose` is abandoned (supply chain risk)
+- **Package:** `python-jose` 3.5.0 (locked)
+- **Issue:** No releases since 2021. Widely considered abandoned. FastAPI documentation has moved to recommending PyJWT. An abandoned cryptographic library will not receive patches for future vulnerabilities.
+- **Recommendation:** Replace `python-jose[cryptography]` with `PyJWT[crypto]` (near drop-in replacement).
+- **Status:** Unchanged from 2026-04-07 review — open for 7+ consecutive days.
+
+### 2. `anthropic` SDK has 2 unpatched CVEs (below 0.87.0)
+- **Package:** `anthropic` 0.77.1 (locked)
+- **CVE-2026-34450:** Insecure default file permissions (0o666) in local filesystem memory tool.
+- **CVE-2026-34452:** TOCTOU race condition in memory tool path validation allowing symlink-based sandbox escape.
+- **Fix:** Bump minimum to `anthropic>=0.87.0` and update `uv.lock`.
+- **Status:** Unchanged from 2026-04-07 review — open for 7+ consecutive days.
+
+---
+
+## :orange_circle: WARNING (Address within 1 week)
+
+### 3. Password change only revokes current token, not all sessions
+- **Location:** `winebox/routers/auth.py:170-178`
+- **Issue:** When a user changes their password, only the current session token is revoked. Other active sessions (e.g., on other devices) remain valid for up to 2 hours. An attacker with a stolen token retains access after the victim changes their password.
+- **Also affects:** CLI password change (`winebox/cli/user_admin.py:172-185`) revokes no tokens at all.
+- **Recommendation:** Implement `revoke_all_tokens_for_user()` using a `password_changed_at` timestamp or per-user token generation counter.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 4. Password reset does not invalidate existing tokens
+- **Location:** `winebox/auth/users.py:90-94`
+- **Issue:** The `on_after_reset_password` callback only logs. After a forgot-password reset, all existing JWT sessions remain valid.
+- **Recommendation:** Invoke token invalidation in `on_after_reset_password`.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 5. XSS via inconsistent `escapeHtml()` in JavaScript frontend
+- **Location:** `winebox/static/js/app.js` — multiple locations including the wine detail view (lines 2561, 2566, 2719, 2721, 2736, 2743, 2750, 2757, 2764, 2771, 2778) and activity/transaction feeds (lines 1935, 3019, 4060).
+- **Issue:** Wine data (user-supplied via label scanning, manual entry, or imports) is inserted into template literals without `escapeHtml()`. Other views correctly use `escapeHtml()`, confirming the inconsistency.
+- **Risk:** Primarily self-XSS today (users inject into their own data), but escalates if wine data is ever shared between users.
+- **Recommendation:** Apply `escapeHtml()` consistently to all user-supplied data rendered via `innerHTML` / template literals.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 6. FastAPI-Users auth endpoints lack explicit rate limits
+- **Location:** `winebox/routers/auth.py:42-65`
+- **Issue:** The fastapi-users login, registration, forgot-password, reset-password, and verification routers only get the global default rate limit (60/minute). The custom `/token` endpoint has a proper `30/minute;200/hour` limit. The `POST /api/auth/forgot-password` endpoint is particularly sensitive — it triggers emails and 60/min is too generous.
+- **Recommendation:** Add explicit `@limiter.limit()` decorators to all fastapi-users auth routes.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 7. No rate limits on expensive operations (scan, search, export, demo)
+- **Location:** Multiple routers — `/api/wines/scan`, `/api/wines/checkin`, `/api/search`, `/api/xwines/search`, `/api/xwines/export`, `/api/export/*`, `/api/import/upload`, `/api/demo/install`.
+- **Issue:** These cost-sensitive or resource-intensive endpoints only have the global 60/min default.
+- **Recommendation:** Add per-endpoint rate limits, especially on `/api/wines/scan` and `/api/wines/checkin`.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 8. No MongoDB query timeouts configured
+- **Location:** `winebox/database.py:39-43`
+- **Issue:** The MongoDB client does not set `serverSelectionTimeoutMS`, `socketTimeoutMS`, or `timeoutMS`. No queries use `maxTimeMS`. A slow or hanging query blocks the event loop indefinitely.
+- **Recommendation:** Set `timeoutMS=30000` (or appropriate value) on the MongoDB client.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 9. No timeout on Anthropic API calls
+- **Location:** `winebox/services/vision.py:120`, `winebox/services/vision.py:257`, `winebox/services/xwines_matcher.py:154`, `winebox/services/import_service/mapping.py:194`
+- **Issue:** `client.messages.create()` has no `timeout` parameter. The Anthropic SDK defaults to 10 minutes, far too long for a web request. The import mapping call site was not previously listed.
+- **Recommendation:** Set explicit timeout (e.g., 60 seconds) on all Anthropic API calls — four call sites total.
+- **Status:** Unchanged from 2026-04-07 review — expanded to include `import_service/mapping.py:194` for completeness.
+
+### 10. X-Wines regex search loads all results into memory before paginating
+- **Location:** `winebox/routers/xwines.py:391-393`
+- **Issue:** `_regex_search` fetches ALL matching results for three separate tiers before combining and paginating in Python. Three unbounded `.to_list()` calls are executed per search request.
+- **Recommendation:** Apply `.limit()` at the database query level.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 11. Export endpoints fetch all user data without pagination limits
+- **Location:** `winebox/routers/export.py:57, 157`
+- **Issue:** `wines = await Wine.find(conditions).to_list()` and `transactions = await Transaction.find(conditions).to_list()` fetch all matching documents with no upper bound.
+- **Recommendation:** Add pagination or a maximum export size.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 12. Nightly CI workflow disables SSH host key verification (NEW)
+- **Location:** `.github/workflows/nightly.yml:43` (and `daf62a3` — the fix that introduced it)
+- **Issue:** The nightly OAT deployment writes an SSH config with `StrictHostKeyChecking no` and `UserKnownHostsFile /dev/null` before running `invoke deploy-oat --release --host ${{ secrets.OAT_DROPLET_IP }}`. This disables SSH host key verification entirely, exposing the deploy to a man-in-the-middle attack that could exfiltrate the OAT SSH private key and all deploy-time secrets (`WINEBOX_MONGODB_URL`, `WINEBOX_SECRET_KEY`, `WINEBOX_ANTHROPIC_API_KEY`, AWS credentials, etc.).
+- **Mitigation:** Attack requires a MITM between GitHub's hosted runners and Digital Ocean — not trivial but also not implausible given BGP hijacks and compromised routers. The `winebox-oat` environment is non-production, but the shared MongoDB cluster and AWS keys are not.
+- **Recommendation:** Fetch the droplet's host key at provisioning time and store it as a GitHub secret (`OAT_SSH_KNOWN_HOSTS`). Write it into `~/.ssh/known_hosts` at job start, and restore `StrictHostKeyChecking yes`. Alternatively, run `ssh-keyscan -H $OAT_DROPLET_IP >> ~/.ssh/known_hosts` and pin the fingerprint via a separate secret.
+- **Status:** New finding — introduced in commits `94aa57e` and `daf62a3`.
+
+---
+
+## :yellow_circle: INFO (Best practice recommendations)
+
+### 13. `.gitignore` missing coverage for `secrets.env`, `*.pem`, `*.key`, `*.p12`
+- **Location:** `.gitignore`
+- **Issue:** While `.env` is covered, `secrets.env`, `*.pem`, `*.key`, `*.p12`, and `*.pfx` are not explicitly listed. An accidental `git add` could commit sensitive files.
+- **Recommendation:** Add explicit entries for these patterns.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 14. `.playwright-mcp/` directory tracked in git, leaks server hostnames
+- **Location:** `.playwright-mcp/` (multiple YAML files)
+- **Issue:** Playwright MCP session snapshots are committed to git and contain server infrastructure details (e.g., `Server: shared.2t22cum.mongodb.net`). Still tracked as of `daf62a3` — confirmed 4 files plus a `.crx` browser extension archive in the directory.
+- **Recommendation:** Add `.playwright-mcp/` to `.gitignore` and remove from tracking.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 15. Label images served without authentication
+- **Location:** `winebox/main.py:341`
+- **Issue:** Wine label images are served as static files at `/api/images/` with no authentication. Filenames are UUIDs (hard to guess), but no access control exists.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 16. `skip`/`limit` parameters lack upper bounds on multiple endpoints
+- **Locations:** `winebox/routers/wines/crud.py:22`, `winebox/routers/search.py:40-41`, `winebox/routers/transactions.py:24-25`, `winebox/routers/cellar.py:23`, `winebox/routers/met.py:18`
+- **Issue:** A client could pass `limit=999999999` to force the server to serialize a very large result set. Note: `price_tracker.py:229, 308` applies a manual cap of 200 — demonstrating that a consistent pattern is possible.
+- **Recommendation:** Add `Query(le=500)` or similar to all `limit` parameters.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 17. Import file upload has no size limit
+- **Location:** `winebox/routers/import_router.py:130`
+- **Issue:** `file_bytes = await file.read()` without checking file size.
+- **Recommendation:** Add size validation before reading import files.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 18. Minimum password length is only 6 characters
+- **Location:** `winebox/auth/schemas.py:10`
+- **Issue:** `MIN_PASSWORD_LENGTH = 6` with no complexity requirements. NIST 800-63B recommends minimum 8 characters.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 19. Loose lower bounds on dependency versions
+- **`python-multipart>=0.0.6`:** CVE-2026-24486 fixed in 0.0.22.
+- **`jinja2>=3.1.0`:** CVE-2025-27516 fixed in 3.1.6.
+- **Recommendation:** Bump minimums in `pyproject.toml` to match the locked versions.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 20. `collection` query parameter not validated against enum
+- **Location:** `winebox/routers/wines/crud.py:32`, `winebox/routers/search.py:51`
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 21. Path traversal not validated in `delete_image`/`get_image_path`
+- **Location:** `winebox/services/image_storage.py:177-208`
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 22. `owner_id` exposed in export/import data
+- **Location:** `winebox/routers/export.py:91`, `winebox/routers/import_router.py:766`
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 23. No `server_tokens off` in nginx config
+- **Location:** `deploy/nginx-winebox.conf`
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 24. Inline script in `og-preview.html`
+- **Location:** `winebox/static/og-preview.html:132`
+- **Status:** Unchanged from 2026-04-07 review (dev/preview utility, not user-facing).
+
+### 25. OAT nginx has no admin IP restriction
+- **Location:** `deploy/nginx-winebox-oat.conf`
+- **Status:** Unchanged from 2026-04-07 review. Mitigated by server-side `RequireAdmin`.
+
+### 26. Missing try/except on ObjectId parsing in `price_tracker`
+- **Location:** `winebox/routers/price_tracker.py:247, 267, 304`
+- **Issue:** Three `ObjectId(wine_price_id)` calls still throw `InvalidId` → 500 instead of a clean 404.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 27. Missing `max_length` on Form fields in `price_tracker`
+- **Location:** `winebox/routers/price_tracker.py:123-128`
+- **Issue:** `shop_name`, `town_city`, `state_county`, `country`, and `currency` still lack `max_length` constraints. Only `wine_name` (500) and `notes` (2000) are bounded by explicit `len()` checks.
+- **Status:** Unchanged from 2026-04-07 review.
+
+### 28. DigitalOcean API calls have no timeout
+- **Location:** `deploy/common.py` (~10 call sites)
+- **Status:** Unchanged from 2026-04-07 review. Deploy-time only, not runtime.
+
+### 29. Admin info endpoint exposes MongoDB hostname
+- **Location:** `admin/admin_app/routers/admin.py:35-42`
+- **Status:** Unchanged from 2026-04-07 review. Gated behind `RequireAdmin`.
+
+### 30. Nightly auto-fix job gives Claude Code write access to the repo (NEW)
+- **Location:** `.github/workflows/nightly.yml:113-185`
+- **Issue:** The `auto-fix` job invokes `anthropics/claude-code-action@v1` with `allowed_tools: "Bash,Read,Write,Edit,Grep,Glob"` and a prompt built from the E2E test failure output (`${{ steps.failures.outputs.failures }}`). The failure lines are produced by pytest, but they include test names, assertion text, and captured stdout — any of which could potentially contain attacker-influenced strings if a prompt-injection vector ever leaks into test output (e.g. through data imported into OAT from Kaggle/X-Wines scrapes). A successful injection could cause Claude to run arbitrary bash on the runner.
+- **Mitigation:** The auto-fix runs on a GitHub-hosted ephemeral runner with a scoped `GITHUB_TOKEN`, and the PR it opens still requires human review before merge.
+- **Recommendation:** Consider: (a) sandbox `allowed_tools` to `Read,Grep,Glob` for the diagnosis step and only enable write access after a human approval, (b) strip control characters and truncate failure text aggressively before feeding it into the prompt, (c) never feed raw test stdout into prompts — only the assertion header lines.
+- **Status:** New finding — introduced in commit `94aa57e`.
+
+---
+
+## :green_circle: CLEAN (Passed review)
+
+### Authentication & Core Security
+- All user-data endpoints require `RequireAuth` and filter by `owner_id` — no missing auth or owner scoping found
+- All admin endpoints use `RequireAdmin` (not just `RequireAuth`)
+- Password hashing uses Argon2 via `pwdlib` — industry-standard memory-hard algorithm
+- Constant-time password comparison with anti-enumeration dummy hash verification
+- Account lockout after failed login attempts with `Retry-After` header
+- JWT tokens include unique `jti` for revocation; token blacklist checked on every request
+- Startup validates secret key length >= 32 characters in production
+- New bottle/case endpoints (`ad74c00`) correctly scope by `current_user.id` and use try/except on ObjectId
+
+### Input Validation
+- All API inputs use Pydantic models with field constraints
+- All regex patterns from user input use `re.escape()`
+- No unsafe MongoDB operators (`$expr`, `$where`, `$function`, `$accumulator`) used
+- No NoSQL injection vectors found — all queries use typed parameters, not string interpolation
+- Search query length limited to 200 characters
+- File uploads validate size, extension (allowlist), and magic bytes
+
+### Security Headers & Transport
+- Full security header suite: X-Content-Type-Options, X-Frame-Options, CSP, HSTS, Referrer-Policy, Permissions-Policy
+- No `unsafe-inline` for `script-src` in CSP
+- CORS defaults to same-origin only (empty origins list)
+- HTTPS enforced in production with HSTS preload
+- TLS 1.2+ only with strong cipher suites in nginx
+
+### Secrets Management
+- No hardcoded secrets found in codebase (only test fixtures with obvious dummy values)
+- No secrets ever committed to git history
+- API keys loaded from environment variables / secrets files
+- Secrets not logged in error messages or security events
+- All GitHub Actions workflows consume secrets via `${{ secrets.* }}` — none are hardcoded
+
+### Dependencies (resolved versions)
+- `cryptography` 46.0.5 — patched for CVE-2026-26007
+- `pillow` 12.1.1 — patched for CVE-2026-25990
+- `jinja2` 3.1.6 — patched for CVE-2025-27516
+- `python-multipart` 0.0.22 — patched for CVE-2026-24486
+- `fastapi` 0.128.1, `uvicorn` 0.40.0, `pymongo` 4.16.0, `pydantic` 2.12.5, `httpx` 0.28.1 — all at current versions with no known CVEs
+- All other major dependencies at current versions with no known CVEs
+
+### Infrastructure
+- Production database safety guard prevents non-production hosts from connecting to production DB
+- Debug mode blocked in production via startup validation
+- No sensitive data in error messages or stack traces
+- Admin panel IP-restricted in production nginx config
+
+---
+
+## :bar_chart: Summary
+
+| Metric | Value |
+|--------|-------|
+| **Date of review** | 2026-04-13 |
+| **Critical issues** | 2 (unchanged) |
+| **Warning issues** | 10 (+1 new) |
+| **Info issues** | 18 (+1 new) |
+| **Clean areas** | 6 categories |
+
+### Comparison with 2026-04-07 Review
+
+- **Critical:** Both issues (#1 python-jose, #2 anthropic CVEs) remain open — now 7+ days without remediation.
+- **Warning:** All 9 previous warnings remain open. 1 new warning added:
+  - **#12** — Nightly CI disables SSH host key verification (`StrictHostKeyChecking no` + `/dev/null` known_hosts) for the OAT deploy, exposing deploy-time secrets to MITM.
+- **Info:** All 17 previous info items remain open. 1 new info item added:
+  - **#30** — The nightly `auto-fix` job grants Claude Code full read/write/bash access and builds its prompt from raw pytest failure output, creating a prompt-injection surface.
+- **Code changes since last review:** 7 commits, none touching auth, input validation, or database query code. The only runtime change was `ad74c00` (sync `Wine.inventory.quantity` on bottle/case creation) — reviewed and clean. All other commits are tests and CI workflow additions.
+- **No regressions** introduced in the non-CI code.
+
+### Top 3 Priorities
+
+1. **Replace `python-jose` with `PyJWT` and bump `anthropic>=0.87.0`** — Two critical dependency issues now in their seventh consecutive day without remediation. An abandoned cryptographic library and two unpatched CVEs in the Anthropic SDK.
+
+2. **Fix SSH host key verification in the nightly CI workflow (#12)** — `StrictHostKeyChecking no` paired with `UserKnownHostsFile=/dev/null` is a meaningful MITM risk that exposes the OAT SSH key plus `WINEBOX_MONGODB_URL`, `WINEBOX_SECRET_KEY`, `WINEBOX_ANTHROPIC_API_KEY`, and AWS credentials on every scheduled run. Easy fix: bake the droplet host key into a GitHub secret.
+
+3. **Implement full token invalidation on password change/reset (#3, #4)** — Currently only the current session is revoked, leaving other sessions (potentially attacker-controlled) active for up to 2 hours. This violates the project's own CLAUDE.md security guidelines.


### PR DESCRIPTION
## Summary

Daily security review for 2026-04-13.

**Findings:**
- 🔴 **2 CRITICAL** (unchanged — 7 consecutive days)
- 🟠 **10 WARNING** (+1 new)
- 🟡 **18 INFO** (+1 new)

### New warning
- **#12** — Nightly CI workflow disables SSH host key verification (`StrictHostKeyChecking no` + `UserKnownHostsFile /dev/null`) for the OAT deploy, exposing deploy-time secrets (`WINEBOX_MONGODB_URL`, `WINEBOX_SECRET_KEY`, `WINEBOX_ANTHROPIC_API_KEY`, AWS credentials) to MITM. Introduced in commits `94aa57e` and `daf62a3`.

### New info
- **#30** — The nightly `auto-fix` job grants `anthropics/claude-code-action@v1` full `Bash,Read,Write,Edit,Grep,Glob` access and builds its prompt from raw pytest failure output, creating a prompt-injection surface.

### Still outstanding (critical)
1. `python-jose` 3.5.0 — abandoned since 2021 (recommend migration to `PyJWT`).
2. `anthropic` 0.77.1 — below 0.87.0 which patches CVE-2026-34450 and CVE-2026-34452.

Both critical items are now in their seventh consecutive day without remediation.

Full report: `docs/security-reports/2026-04-13.md`

## Test plan
- [x] Review rendered markdown in the PR diff
- [ ] Confirm the two new findings match what the maintainer expects from recent CI changes
