### PR TITLE
Security Review — 2026-04-17 (security-critical)

### DIFF
--- a/docs/security-reports/2026-04-17.md
+++ b/docs/security-reports/2026-04-17.md
@@ -1,0 +1,359 @@
+# WineBox Security Review — 2026-04-17
+
+## :red_circle: CRITICAL (Immediate action required)
+
+### 1. `cryptography` 46.0.5 has two unpatched CVEs (new finding)
+- **Package:** `cryptography` 46.0.5 (confirmed in `uv.lock`)
+- **CVE-2026-39892 (CVSS 6.9, Medium):** Buffer overflow via non-contiguous
+  buffers passed to APIs like `Hash.update()`. Affects versions 45.0.0
+  through 46.0.6. Fixed in **46.0.7**.
+- **CVE-2026-34073 (Information Disclosure):** Incomplete DNS name constraint
+  enforcement on peer names. Fixed in **46.0.6**.
+- **Recommendation:** Bump `cryptography>=46.0.7` in `pyproject.toml` and
+  refresh `uv.lock`.
+- **Status:** New finding.
+
+### 2. `python-multipart` 0.0.22 has a DoS CVE (new finding)
+- **Package:** `python-multipart` 0.0.22 (confirmed in `uv.lock`)
+- **CVE-2026-40347 (Moderate):** Denial of Service via large multipart
+  preamble or epilogue data. All versions before 0.0.26 are affected.
+  Fixed in **0.0.26**.
+- **Recommendation:** Bump `python-multipart>=0.0.26` in `pyproject.toml` and
+  refresh `uv.lock`.
+- **Status:** New finding.
+
+### 3. `python-jose` is abandoned (supply chain risk)
+- **Package:** `python-jose` 3.5.0 (confirmed in `uv.lock`)
+- **Issue:** No reliable maintainer. FastAPI documentation recommends PyJWT.
+  `pyjwt` 2.11.0 is already resolved in the lock file as a transitive
+  dependency — a straight swap is feasible.
+- **Recommendation:** Replace `python-jose[cryptography]` with `PyJWT[crypto]`.
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### CORRECTION: `anthropic` SDK CVEs do not affect pinned version
+- **Previous reports** listed CVE-2026-34450 and CVE-2026-34452 as CRITICAL
+  for `anthropic` 0.77.1. Further investigation reveals these CVEs affect
+  versions **0.86.0 to 0.87.0** only — they were introduced in the local
+  filesystem memory tool feature added in 0.86.0. Version 0.77.1 **predates
+  the vulnerable code** and is not affected.
+- **Downgraded** from CRITICAL to INFO (see item #33 below for version gap
+  concern).
+- Effective critical count drops from 2 → 3 total (2 new dependency CVEs +
+  1 existing `python-jose`), but the long-standing `anthropic` critical is
+  removed.
+
+---
+
+## :orange_circle: WARNING (Address within 1 week)
+
+### 4. `Pillow` 12.1.1 has a decompression bomb CVE (new finding)
+- **Package:** `Pillow` 12.1.1 (confirmed in `uv.lock`)
+- **CVE-2026-40192 (Medium):** GZIP decompression bomb via FITS images
+  causing unbounded memory consumption. Fixed in **12.2.0**.
+- **Recommendation:** Bump `pillow>=12.2.0` in `pyproject.toml` and refresh
+  `uv.lock`.
+- **Status:** New finding.
+
+### 5. Price tracker leaks other users' PII
+- **Location:** `winebox/routers/price_tracker.py:54-84` (`_entry_to_out`),
+  used by `get_wine_price` at `winebox/routers/price_tracker.py:241-250`.
+- **Issue:** `WinePrice` is a global crowdsourced document: a user who
+  contributed a price entry for a given wine can read the full document via
+  `GET /api/prices/{wine_price_id}`, which includes **every** contributor's
+  entries. `_entry_to_out` emits for each entry:
+  - `owner_id` (raw `PyObjectId` serialised to string — line 73) — allows
+    enumeration of other users' MongoDB IDs.
+  - `coordinates` (latitude/longitude + accuracy_metres — lines 60-66) — GPS
+    location where the photograph was taken.
+  - `shop_name`, `town_city`, `state_county`, `country`, `notes` — shop
+    location text and free-form notes, potentially PII.
+- **Recommendation:** In `_entry_to_out`, only include `owner_id`,
+  `coordinates`, `notes`, and `photo_url` when
+  `entry.owner_id == current_user.id`. For other users' entries, return only
+  aggregate fields (`price`, `currency`, `timestamp`, `shop_name`,
+  `country`). Alternatively, fuzz coordinates to ~1 km accuracy.
+- **Status:** Unchanged since 2026-04-14 (first reported). Now 3 days open.
+
+### 6. Password change only revokes current token, not all sessions
+- **Location:** `winebox/routers/auth.py:170-178`;
+  `winebox/cli/user_admin.py:172-185` revokes no tokens at all.
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 7. Password reset does not invalidate existing tokens
+- **Location:** `winebox/auth/users.py:90-94`
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 8. XSS via inconsistent `escapeHtml()` in JavaScript frontend
+- **Location:** `winebox/static/js/app.js` — card view, detail view, activity
+  feed, transaction history all insert wine fields via `innerHTML` without
+  `escapeHtml()`. Spot-checked the new code and the pattern persists.
+  Additionally, line 2561 uses `alt="${wine.name}"` without `escapeHtml()`
+  in an `innerHTML` context, which could break out of the alt attribute.
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 9. FastAPI-Users auth endpoints lack explicit rate limits
+- **Location:** `winebox/routers/auth.py:42-65`
+- **Issue:** The fastapi-users router endpoints (`/login`, `/register`,
+  `/forgot-password`, `/reset-password`, `/request-verify-token`, `/verify`)
+  fall back to the global 60/minute limit. The custom `/api/auth/token`
+  has 30/minute, and `/api/auth/password` has 5/minute, but the
+  fastapi-users equivalents run at the more permissive rate.
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 10. No rate limits on expensive operations
+- **Location:** `/api/wines/scan`, `/api/wines/enrich`, `/api/search`,
+  `/api/xwines/search`, `/api/xwines/export`, `/api/export/*`,
+  `/api/import/upload`, `/api/demo/install`,
+  `POST /api/prices` (10 MB multipart upload per call).
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 11. No MongoDB query timeouts configured
+- **Location:** `winebox/database.py:39-43`
+- **Issue:** `AsyncMongoClient` has no `serverSelectionTimeoutMS`,
+  `socketTimeoutMS`, or `connectTimeoutMS`. No `.max_time_ms()` on queries.
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 12. No timeout on Anthropic API calls
+- **Location:** `winebox/services/vision.py:120`,
+  `winebox/services/xwines_matcher.py:154`
+- **Issue:** Anthropic SDK default timeout is 10 minutes — far too long for a
+  web request handler.
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 13. X-Wines regex search loads all results into memory before paginating
+- **Location:** `winebox/routers/xwines.py:391-393`
+- **Status:** Unchanged since 2026-04-06. Now 11 days open.
+
+### 14. Export endpoints fetch all user data without pagination limits
+- **Location:** `winebox/routers/export.py:57, 157`
+- **Status:** Unchanged since 2026-04-07. Now 10 days open.
+
+---
+
+## :yellow_circle: INFO (Best practice recommendations)
+
+### 15. Emacs auto-save and lock files tracked in git
+- **Location:** `docs/#schema-diagram.md#`, `docs/.#schema-diagram.md`
+- **Issue:** Lock symlink leaks developer username and hostname:
+  `jdrumgoole@macmini.lan.33221`.
+- **Status:** Unchanged since 2026-04-14.
+
+### 16. ObjectId parsed without try/except in price_tracker
+- **Location:** `winebox/routers/price_tracker.py:247, 267, 304`
+- **Issue:** `ObjectId(wine_price_id)` raises `bson.errors.InvalidId` on a
+  malformed ID, surfacing as a 500 instead of a clean 404.
+- **Status:** Unchanged since 2026-04-07. Persists after rewrite.
+
+### 17. Form fields in price_tracker lack `max_length`
+- **Location:** `winebox/routers/price_tracker.py:118-132`
+- **Status:** Unchanged since 2026-04-07. Unfixed.
+
+### 18. `POST /api/prices` photo upload size limit is enforced after read
+- **Location:** `winebox/routers/price_tracker.py:168-170`
+- **Issue:** `content = await photo.read()` loads the full upload before the
+  10 MB check fires.
+- **Status:** Unchanged since 2026-04-14.
+
+### 19. Unbounded `.to_list(length=None)` in cellar and search code paths
+- **Location:** `winebox/routers/cellar.py:125, 172`,
+  `winebox/routers/search.py:132, 157, 176`,
+  `winebox/routers/bottles.py:73`, `winebox/routers/cases.py:195`
+- **Issue:** All scoped by `owner_id`, but a user with a very large cellar
+  can force unbounded memory use per request.
+- **Status:** Unchanged since 2026-04-14.
+
+### 20. `.gitignore` missing `secrets.env`, `*.pem`, `*.key`, `*.p12`, `.playwright-mcp/`, Emacs temp files
+- **Location:** `.gitignore`
+- **Status:** Unchanged since 2026-04-06. `.playwright-mcp/` still tracked
+  and still leaks `Server: shared.2t22cum.mongodb.net`.
+
+### 21. Label images served without authentication
+- **Location:** `winebox/main.py:341` — `/api/images/` served as static.
+- **Status:** Unchanged since 2026-04-06.
+
+### 22. `skip`/`limit` lack upper bounds on multiple endpoints
+- **Location:** `winebox/routers/wines/crud.py:22`,
+  `winebox/routers/search.py:41-42`, `winebox/routers/transactions.py:24-25`,
+  `winebox/routers/cellar.py:23-24`, `winebox/routers/met.py:18`.
+- **Status:** Unchanged since 2026-04-06.
+
+### 23. Import file upload has no size limit
+- **Location:** `winebox/routers/import_router.py:130`
+- **Status:** Unchanged since 2026-04-06.
+
+### 24. Minimum password length is only 6 characters
+- **Location:** `winebox/auth/schemas.py:10`
+- **Issue:** NIST recommends 8+. Admin user creation enforces 8 (inconsistent).
+- **Status:** Unchanged since 2026-04-06.
+
+### 25. Loose lower bound on `jinja2`
+- **Location:** `pyproject.toml:33`. Lock file resolves safely (`jinja2`
+  3.1.6) but lower bound still permits vulnerable installs.
+- **Status:** Unchanged since 2026-04-06. Note: `python-multipart` lower
+  bound issue is now escalated to CRITICAL (#2).
+
+### 26. `collection` query param not validated against enum
+- **Location:** `winebox/routers/wines/crud.py:32`,
+  `winebox/routers/search.py:52`
+- **Status:** Unchanged since 2026-04-06.
+
+### 27. Path traversal not validated in image storage helpers
+- **Location:** `winebox/services/image_storage.py:177-208`. Mitigated by
+  UUID filenames on save and DB-sourced filenames on delete.
+- **Status:** Unchanged since 2026-04-06.
+
+### 28. `owner_id` exposed in export/import data
+- **Location:** `winebox/routers/export.py:91`,
+  `winebox/routers/import_router.py:766`
+- **Status:** Unchanged since 2026-04-06.
+
+### 29. No `server_tokens off` in nginx config
+- **Location:** `deploy/nginx-winebox.conf`
+- **Status:** Unchanged since 2026-04-06.
+
+### 30. Inline script in `og-preview.html`
+- **Location:** `winebox/static/og-preview.html:132`
+- **Status:** Unchanged since 2026-04-06.
+
+### 31. OAT nginx has no admin IP restriction
+- **Location:** `deploy/nginx-winebox-oat.conf`
+- **Status:** Unchanged since 2026-04-07.
+
+### 32. DigitalOcean API calls in `deploy/common.py` have no timeout
+- **Location:** `deploy/common.py` lines 142, 161, 191, 211, 222, 232, 242,
+  252, 268, 286
+- **Status:** Unchanged since 2026-04-07.
+
+### 33. `anthropic` SDK is 19 minor versions behind latest
+- **Package:** `anthropic` 0.77.1 (locked) vs ~0.96.0 (latest)
+- **Issue:** Large version gap means missing security hardening and bug fixes.
+  No current CVE exposure (see CORRECTION above), but the gap itself is a
+  maintenance risk.
+- **Status:** Downgraded from CRITICAL. Version gap concern only.
+
+### 34. Admin info endpoint exposes MongoDB hostname
+- **Location:** `admin/admin_app/routers/admin.py:35-42`
+- **Status:** Unchanged since 2026-04-07.
+
+### 35. `scrape_wine_prices.py` Playwright context has no navigation timeout
+- **Location:** `scripts/scrape_wine_prices.py`
+- **Status:** Unchanged since 2026-04-14.
+
+### 36. FastAPI auto-docs enabled in production (new finding)
+- **Location:** `winebox/main.py:233`
+- **Issue:** `/docs`, `/redoc`, and `/openapi.json` are accessible in
+  production, exposing the full API schema to potential attackers.
+- **Recommendation:** Set `docs_url=None`, `redoc_url=None`,
+  `openapi_url=None` in production, or gate behind admin auth.
+- **Status:** New finding.
+
+### 37. HSTS header dropped for nginx-served static files (new finding)
+- **Location:** `deploy/nginx-winebox.conf:179-184`
+- **Issue:** nginx `add_header` directives are not inherited into `location`
+  blocks that contain their own `add_header`. The `/static/` location adds
+  `Cache-Control`, which silently drops HSTS for those responses. The
+  application middleware covers proxied responses, but static files served
+  directly by nginx miss HSTS.
+- **Recommendation:** Add `add_header Strict-Transport-Security` to every
+  `location` block that uses `add_header`, or use the `more_set_headers`
+  module.
+- **Status:** New finding.
+
+### 38. Missing `max_length` on query parameters in xwines and reference routers (new finding)
+- **Location:** `winebox/routers/xwines.py:472, 475, 476`,
+  `winebox/routers/reference.py:62-64, 116, 119, 295, 296`
+- **Issue:** 10 query parameters that flow into MongoDB regex queries lack
+  `max_length` constraints. Compare to `search.py` which correctly applies
+  `max_length=200`.
+- **Status:** New finding.
+
+---
+
+## :green_circle: CLEAN (Passed review)
+
+### Authentication & owner scoping
+- All user-data endpoints use `RequireAuth` and scope every query by
+  `cellar_id: current_user.id` or `owner_id: current_user.id`. No missing
+  auth found. Every endpoint in `cellar.py`, `bottles.py`, `cases.py`,
+  `met.py`, `transactions.py`, `search.py`, `export.py`, `import_router.py`,
+  `demo.py`, and `wines/` was individually verified.
+- Admin endpoints all use `RequireAdmin`. Only `admin/auth.py:/me` uses
+  `RequireAuth` with an internal `is_superuser` check — functionally
+  equivalent but inconsistent with the pattern.
+- Password hashing (Argon2 via `pwdlib`), constant-time comparison, anti-
+  enumeration dummy hash, account lockout with `Retry-After`, JWT `jti`
+  blacklist, startup secret-length validation — all still in place.
+
+### NoSQL injection
+- No `$where`, `$expr`, `$function`, or `$accumulator` operators anywhere.
+- All regex uses of user input go through `re.escape()` (verified in
+  `search.py`, `reference.py`, `xwines.py`, `wines/crud.py`,
+  `xwines_enrichment.py`).
+- No user input placed into MongoDB operator positions. FastAPI typed
+  parameters prevent dict-type injection.
+- All `$in` queries use server-generated arrays, never user-supplied.
+
+### Input validation
+- All JSON body endpoints use Pydantic models. No raw `dict` bodies.
+- File uploads validate type, size, and magic bytes. User-supplied filenames
+  are discarded in favour of UUID-generated names.
+- Jinja2 templates have `autoescape=True`. Email templates render only
+  server-controlled values.
+
+### Secrets management
+- No hardcoded secrets, connection strings, or API keys found anywhere in
+  the codebase. All values are test/placeholder (`"test-key"`,
+  `AKIAIOSFODNN7EXAMPLE`, `mongodb://localhost:27017`).
+- No `.env`, `.key`, `.pem`, or credential files tracked in git.
+- E2E test secret key in `tasks.py` is explicitly labelled non-production.
+
+### Security headers
+- Full CSP, HSTS (application-level), X-Frame-Options, X-Content-Type-Options,
+  Permissions-Policy implemented in `SecurityHeadersMiddleware`.
+- CORS is whitelist-only (default: empty = same-origin).
+
+### Git history
+- No security regressions in the last 30 commits. Dominant changes are brand
+  kit updates and version bumps (0.7.38–0.7.42).
+- No accidentally committed secrets in git history.
+
+---
+
+## :bar_chart: Summary
+
+| Metric | Value |
+|--------|-------|
+| **Date of review** | 2026-04-17 |
+| **Critical issues** | 3 (2 new dependency CVEs + 1 unchanged `python-jose`) |
+| **Warning issues** | 11 (+1 new — Pillow CVE; `anthropic` downgraded from previous CRITICAL) |
+| **Info issues** | 24 (+3 new — auto-docs, HSTS static files, query param max_length) |
+| **Clean areas** | 5 categories |
+
+### Comparison with 2026-04-14 Review
+
+- **Critical (3):** Two new dependency CVEs (`cryptography` CVE-2026-39892 +
+  CVE-2026-34073, `python-multipart` CVE-2026-40347). `python-jose` still
+  unfixed (11 days open). **`anthropic` SDK downgraded** — the two CVEs
+  (CVE-2026-34450, CVE-2026-34452) affect versions 0.86.0–0.87.0 only;
+  our pinned 0.77.1 predates the vulnerable feature and is not affected.
+  Previous reports' CRITICAL classification was based on an incorrect version
+  range interpretation.
+- **Warning (+1):** New Pillow decompression bomb CVE. All previous warnings
+  remain open.
+- **Info (+3):** FastAPI auto-docs in production (#36), HSTS header dropped
+  for nginx static files (#37), missing max_length on 10 query parameters
+  (#38). All previous info items unchanged.
+- **No regressions** in authentication, owner scoping, injection prevention,
+  or secret handling since last review.
+
+### Top 3 Priorities
+
+1. **Bump `cryptography>=46.0.7` and `python-multipart>=0.0.26` (#1, #2).**
+   Active CVEs in production dependencies. Both are one-line version bumps
+   in `pyproject.toml` + lock file refresh.
+2. **Fix price tracker PII leak (#5).** `GET /api/prices/{id}` exposes other
+   users' ObjectIds and GPS coordinates. High-impact privacy bug requiring a
+   small change in `_entry_to_out`.
+3. **Replace `python-jose` with `PyJWT` (#3) and implement full token
+   invalidation on password change/reset (#6, #7).** Both 11 days open and
+   violate the project's own security guidelines.


### PR DESCRIPTION
## Summary

- **3 CRITICAL** findings: 2 new dependency CVEs (`cryptography` CVE-2026-39892 + CVE-2026-34073, `python-multipart` CVE-2026-40347) and the ongoing `python-jose` abandonment risk
- **11 WARNING** findings: 1 new (Pillow decompression bomb CVE), 10 unchanged from prior reviews
- **24 INFO** findings: 3 new (FastAPI auto-docs in production, HSTS on nginx static files, missing query param max_length), 21 unchanged
- **CORRECTION:** `anthropic` SDK CVEs (CVE-2026-34450, CVE-2026-34452) downgraded from CRITICAL — they affect versions 0.86.0–0.87.0 only; our pinned 0.77.1 is not affected

### Top 3 Priorities

1. Bump `cryptography>=46.0.7` and `python-multipart>=0.0.26` — active CVEs, one-line fixes
2. Fix price tracker PII leak — `GET /api/prices/{id}` exposes other users' ObjectIds and GPS coordinates
3. Replace `python-jose` with `PyJWT` and implement full token invalidation on password change/reset

https://claude.ai/code/session_01C3RjcjN4hRzYcmXq5Te5FL