### PR TITLE
Security Review — 2026-04-19 (security-warning)

### DIFF
--- a/docs/security-reports/2026-04-19.md
+++ b/docs/security-reports/2026-04-19.md
@@ -1,0 +1,203 @@
+# WineBox Security Review — 2026-04-19
+
+## :red_circle: CRITICAL (Immediate action required)
+
+None.
+
+---
+
+## :orange_circle: WARNING (Address within 1 week)
+
+### 1. PyJWT 2.11.0 has CVE-2026-32597 (new finding)
+- **Package:** `pyjwt` 2.11.0 (confirmed in `uv.lock`)
+- **CVE-2026-32597 (CVSS 7.5 / 8.7):** PyJWT fails to validate the `crit`
+  (Critical) Header Parameter defined in RFC 7515 §4.1.11. When a JWS token
+  contains a `crit` array listing extensions that PyJWT does not understand,
+  the library accepts the token instead of rejecting it. This violates the
+  MUST requirement in the RFC, potentially allowing attackers to bypass
+  security controls by crafting tokens with critical extensions that should be
+  enforced but are silently ignored.
+- **Affected versions:** All versions before 2.12.0.
+- **Recommendation:** Bump `pyjwt>=2.12.0` in `pyproject.toml` and refresh
+  `uv.lock`.
+- **Status:** New finding. Note that this package was only recently introduced
+  (replacing `python-jose` in commit `fb5f462`), so the vulnerability window
+  has been short.
+
+---
+
+## :yellow_circle: INFO (Best practice recommendations)
+
+None.
+
+---
+
+## :green_circle: CLEAN (Passed review)
+
+### Dependency versions
+- **`cryptography` 46.0.7** — CVE-2026-39892 and CVE-2026-34073 patched
+  (was CRITICAL in 2026-04-17 review). ✅
+- **`python-multipart` 0.0.26** — CVE-2026-40347 patched (was CRITICAL). ✅
+- **`pillow` 12.2.0** — CVE-2026-25990 and CVE-2026-40192 patched (was
+  WARNING). ✅
+- **`python-jose` replaced with `PyJWT`** — supply chain risk eliminated
+  (was CRITICAL). ✅
+- **`anthropic` 0.96.0** — CVE-2026-34450 and CVE-2026-34452 patched (both
+  affect 0.86.0–0.87.0 only; 0.96.0 includes the fixes). Version gap closed.
+- **`fastapi` 0.128.1** — no known CVEs. ✅
+- **`pymongo` 4.16.0** — no known CVEs. ✅
+- **`jinja2` 3.1.6** — no known CVEs in the core library. ✅
+- **`uvicorn` 0.40.0** — no known CVEs. ✅
+- **`bcrypt` 5.0.0** — no known CVEs. ✅
+- **`httpx` 0.28.1** — no known CVEs. ✅
+- **`openpyxl` 3.1.5** — no known CVEs. ✅
+- **`slowapi` 0.1.9** — no known CVEs. ✅
+- **`posthog` 7.9.3** — no known CVEs. ✅
+- **`pydantic` 2.12.5** — no known CVEs. ✅
+
+### Authentication & authorization
+- All 50+ user-data endpoints require `RequireAuth` and scope every query by
+  `owner_id` or `cellar_id`. No missing auth found. Every endpoint in
+  `cellar.py`, `bottles.py`, `cases.py`, `met.py`, `transactions.py`,
+  `search.py`, `export.py`, `import_router.py`, `demo.py`, `images.py`,
+  `price_tracker.py`, and `wines/` was individually verified.
+- Admin endpoints all use `RequireAdmin`.
+- Password hashing (Argon2 via `pwdlib`), constant-time comparison,
+  anti-enumeration dummy hash, account lockout with `Retry-After`, JWT `jti`
+  blacklist, startup secret-length validation (32+ chars) — all in place.
+- **Password change now invalidates all user tokens** (was WARNING #6). ✅
+- **Password reset now invalidates all user tokens** via
+  `on_after_reset_password → revoke_all_user_tokens()` (was WARNING #7). ✅
+- Minimum password length raised to 8 characters (was INFO #24). ✅
+
+### Rate limiting & DoS prevention
+- **FastAPI-Users auth endpoints now have explicit rate limits** via
+  `_apply_rate_limits()` (was WARNING #9): login 30/min, register 10/min,
+  forgot-password 5/min, reset-password 5/min, verify 10/min. ✅
+- **Expensive operations now rate-limited** (was WARNING #10): scan 20/min,
+  search 120/min, export 10/min, import 10/min, demo 5/min, price capture
+  30/min. ✅
+- **MongoDB query timeouts now configured** (was WARNING #11):
+  `serverSelectionTimeoutMS=5000`, `connectTimeoutMS=10000`,
+  `socketTimeoutMS=30000`. ✅
+- **Anthropic API timeout now set** (was WARNING #12): 60 seconds. ✅
+- **X-Wines search now bounded** per tier with `MAX_REFERENCE_RESULTSET`
+  (was WARNING #13). ✅
+- **Export endpoints now bounded** with `MAX_USER_RESULTSET` (was WARNING #14). ✅
+- Pagination properly bounded: `MAX_PAGE_SIZE=200`,
+  `MAX_USER_RESULTSET=10,000`, `MAX_REFERENCE_RESULTSET=5,000`.
+- `skip`/`limit` query parameters validated with `ge=0`, `le=MAX_PAGE_SIZE`
+  across all endpoints (was INFO #22). ✅
+- Import file upload now enforced at 25 MB (was INFO #23). ✅
+- DigitalOcean API calls now have 30s timeout (was INFO #32). ✅
+- Playwright scraper now has explicit 20s/15s timeouts (was INFO #35). ✅
+
+### Privacy & data exposure
+- **Price tracker PII leak fixed** (was WARNING #5): `_entry_to_out()` now
+  uses `is_owner` check — GPS coordinates, town/state, notes, photo URLs,
+  and `owner_id` only emitted to the entry owner. ✅
+- **`owner_id` no longer exposed in exports** — `wine_dict.pop("owner_id")`
+  strips it from CSV/XLSX/JSON/YAML output (was INFO #28). ✅
+- **Admin info endpoint no longer exposes MongoDB hostname** — only returns
+  database name; comment explicitly documents the decision (was INFO #34). ✅
+
+### XSS & injection prevention
+- **`escapeHtml()` now used consistently** across all `innerHTML` assignments
+  in `app.js` and `price-tracker.js`. Card view, detail view, activity feed,
+  transaction history, autocomplete, X-Wines detail, and import preview all
+  verified. 127 `escapeHtml` calls covering 67 `innerHTML` assignments (was
+  WARNING #8). ✅
+- No `$where`, `$expr`, `$function`, or `$accumulator` operators anywhere.
+- All regex uses of user input go through `re.escape()`.
+- All JSON body endpoints use Pydantic models. No raw `dict` bodies.
+- `collection` query parameter now validated against `WineCollection` enum
+  (was INFO #26). ✅
+- Query parameters in xwines and reference routers now have `max_length`
+  (was INFO #38). ✅
+- Price tracker form fields now have `max_length` (was INFO #17). ✅
+
+### File upload & image security
+- File uploads validate type, size, and magic bytes. User-supplied filenames
+  discarded in favour of UUID-generated names.
+- **Label images now served with authentication and ownership check** via
+  `images.py` router (was INFO #21). ✅
+- Path traversal protection via `_safe_resolve()` (rejects `..`, `/`, `\\`,
+  verifies resolved path under storage dir).
+- ObjectId parsing in price tracker now uses `_parse_wine_price_id()` helper
+  with proper error handling (was INFO #16). ✅
+
+### Secrets management
+- No hardcoded secrets, connection strings, or API keys found anywhere in
+  the codebase. All values are test/placeholder.
+- No `.env`, `.key`, `.pem`, or credential files tracked in git.
+- E2E test secret key in `tasks.py` is explicitly labelled non-production.
+- **Emacs auto-save/lock files no longer tracked in git** (was INFO #15). ✅
+
+### Security headers & TLS
+- Full CSP, HSTS, X-Frame-Options, X-Content-Type-Options, X-XSS-Protection,
+  Referrer-Policy, Permissions-Policy implemented in
+  `SecurityHeadersMiddleware`.
+- CORS is whitelist-only (default: empty = same-origin).
+- **HSTS now added to all nginx location blocks** including static file
+  locations (was INFO #37). ✅
+- **`server_tokens off`** in both production and OAT nginx configs (was
+  INFO #29). ✅
+- **OAT nginx admin panel now IP-restricted** (was INFO #31). ✅
+- **Inline script in `og-preview.html` replaced with external JS** (was
+  INFO #30). ✅
+- **API docs (`/docs`, `/redoc`, `/openapi.json`) disabled outside debug
+  mode** (was INFO #36). ✅
+- TLS 1.2+ only, ECDHE ciphers, session tickets disabled.
+
+### Infrastructure & configuration
+- Startup validation enforces 32+ character secret key, debug=false in
+  production, warns on localhost MongoDB.
+- nginx: 10 MB upload limit, proxy timeouts, admin IP restriction.
+- Production database safety check prevents non-production hosts from
+  accessing the production database.
+
+### Git history
+- Last 30 commits show active security hardening: auth-gating images,
+  renaming checkin API, scan pipeline unification, rate limiting, DoS
+  hardening, privacy/auth fixes, python-jose→PyJWT migration.
+- No accidentally committed secrets in git history.
+- No security regressions detected.
+
+---
+
+## :bar_chart: Summary
+
+| Metric | Value |
+|--------|-------|
+| **Date of review** | 2026-04-19 |
+| **Critical issues** | 0 |
+| **Warning issues** | 1 (new PyJWT CVE) |
+| **Info issues** | 0 |
+| **Clean areas** | 10 categories |
+
+### Comparison with 2026-04-17 Review
+
+- **Critical (0, was 3):** All three previous criticals resolved:
+  `cryptography` bumped to 46.0.7, `python-multipart` bumped to 0.0.26, and
+  `python-jose` replaced with `PyJWT`.
+- **Warning (1, was 11):** 11 previous warnings all resolved (PII leak,
+  password token revocation, XSS, rate limiting, query timeouts, Anthropic
+  timeout, X-Wines/export bounds, Pillow CVE). One new warning: PyJWT
+  2.11.0 CVE-2026-32597 (crit header bypass).
+- **Info (0, was 24):** All 24 previous info items resolved — password
+  length, form validation, skip/limit bounds, import size limits, gitignore
+  coverage, label image auth, server_tokens, HSTS on static files, auto-docs,
+  admin hostname, Playwright timeouts, collection enum, query param
+  max_length, ObjectId error handling, owner_id export stripping, inline
+  scripts, OAT admin IP, and DigitalOcean API timeouts.
+- **Net change:** −37 issues resolved, +1 new = **36 fewer open issues**.
+
+### Top 3 Priorities
+
+1. **Bump `pyjwt>=2.12.0` (#1).** CVE-2026-32597 allows tokens with
+   unrecognised `crit` extensions to be accepted. One-line version bump in
+   `pyproject.toml` + lock file refresh.
+2. **Continue monitoring dependency advisories.** The recent batch of CVE
+   patches demonstrates the value of prompt upgrades — maintain the cadence.
+3. **No other action required.** The codebase is in excellent security health
+   following the comprehensive hardening over the past two weeks.


### PR DESCRIPTION
## Summary

- **1 WARNING:** PyJWT 2.11.0 has CVE-2026-32597 (crit header bypass) — upgrade to `pyjwt>=2.12.0` required
- **0 CRITICAL, 0 INFO**
- **37 issues from the 2026-04-17 review are now resolved** (3 critical, 11 warning, 23 info)

The codebase is in excellent security health following comprehensive hardening over the past two weeks. The only outstanding item is a single dependency version bump.

## Action Required

Bump `pyjwt>=2.12.0` in `pyproject.toml` and refresh `uv.lock` to address CVE-2026-32597.

https://claude.ai/code/session_013jMyp4dot6epgDJQGadUH7