### PR TITLE
fix(security): redact other users' location/notes in price history

### DIFF
--- a/tests/test_price_tracker.py
+++ b/tests/test_price_tracker.py
@@ -251,9 +251,12 @@ async def test_list_prices_returns_user_wines(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_prices_limit_capped(client: AsyncClient) -> None:
+async def test_list_prices_limit_out_of_range_rejected(client: AsyncClient) -> None:
+    """`limit` is hard-bounded via `Query(..., le=200)` — over-limit is a 422."""
     response = await client.get("/api/prices?limit=500")
-    assert response.status_code == 200
+    assert response.status_code == 422
+    response = await client.get("/api/prices?skip=-1")
+    assert response.status_code == 422
 
 
 # ---------------------------------------------------------------------------
@@ -636,6 +639,105 @@ async def test_history_endpoint_empty_when_no_overflow(client: AsyncClient) -> N
     response = await client.get(f"/api/prices/{body['id']}/history")
     assert response.status_code == 200
     assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_history_redacts_other_users_location_and_notes(
+    client: AsyncClient, init_test_db
+) -> None:
+    """User B fetching archived history for a shared wine must not see
+    User A's granular location (`town_city`, `state_county`) or free-text
+    `notes`. Aggregate fields (shop_name, country, price) stay visible."""
+    name = f"HistoryPII Wine {uuid.uuid4().hex[:6]}"
+
+    # User A seeds enough prices that the earliest one overflows to history.
+    for i in range(21):
+        await _create_price(
+            client,
+            wine_name=name,
+            price=str(10.0 + i),
+            notes="User A private note",
+            shop_name="Vintners Cellar",
+            town_city="Dublin",
+            state_county="Leinster",
+            country="Ireland",
+        )
+
+    # Find the wine_price_id via the list endpoint for user A.
+    list_resp = await client.get("/api/prices")
+    assert list_resp.status_code == 200
+    wine_id = next(
+        s["id"] for s in list_resp.json() if s["wine_name"] == name
+    )
+
+    # User A sees their own history unredacted.
+    hist_a = await client.get(f"/api/prices/{wine_id}/history")
+    assert hist_a.status_code == 200
+    assert hist_a.json(), "expected at least one archived entry"
+    for row in hist_a.json():
+        assert row["location"]["town_city"] == "Dublin"
+        assert row["location"]["state_county"] == "Leinster"
+        assert row["notes"] == "User A private note"
+
+    # User B hits the same endpoint; PII fields must be None.
+    from winebox.models import User
+    from winebox.services.auth import create_access_token
+    from tests.conftest import get_test_app, _CACHED_TEST_PASSWORD_HASH
+
+    other_email = f"other-{uuid.uuid4().hex[:8]}@example.com"
+    other_user = User(
+        email=other_email,
+        hashed_password=_CACHED_TEST_PASSWORD_HASH,
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    await other_user.insert()
+    other_token = create_access_token(data={"sub": other_email})
+    app = get_test_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {other_token}"},
+    ) as other_client:
+        hist_b = await other_client.get(f"/api/prices/{wine_id}/history")
+
+    assert hist_b.status_code == 200
+    rows = hist_b.json()
+    assert rows, "user B should still see the archive rows, just redacted"
+    for row in rows:
+        assert row["location"]["town_city"] is None
+        assert row["location"]["state_county"] is None
+        assert row["notes"] is None
+        # Aggregate fields still visible for price comparison.
+        assert row["location"]["shop_name"] == "Vintners Cellar"
+        assert row["location"]["country"] == "Ireland"
+        assert row["price"] >= 10.0
+        assert row["currency"] == "EUR"
+
+
+@pytest.mark.asyncio
+async def test_history_skip_rejects_negative(client: AsyncClient) -> None:
+    """`skip<0` is a 422, not a silent pass-through to Mongo."""
+    body = await _create_price(
+        client, wine_name=f"NegSkip {uuid.uuid4().hex[:6]}", price="10.00",
+    )
+    resp = await client.get(f"/api/prices/{body['id']}/history?skip=-1")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_history_limit_out_of_range_rejected(client: AsyncClient) -> None:
+    """`limit>200` is a hard 422 now, not the old silent clamp."""
+    body = await _create_price(
+        client, wine_name=f"BigLimit {uuid.uuid4().hex[:6]}", price="10.00",
+    )
+    resp = await client.get(f"/api/prices/{body['id']}/history?limit=500")
+    assert resp.status_code == 422
+    resp = await client.get(f"/api/prices/{body['id']}/history?limit=0")
+    assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------

--- a/winebox/routers/price_tracker.py
+++ b/winebox/routers/price_tracker.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from bson import ObjectId
 from bson.errors import InvalidId
-from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile, status
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import FileResponse
 
 from winebox.config import settings
@@ -256,12 +256,10 @@ async def create_price_capture(
 @router.get("", response_model=list[WinePriceSummaryOut])
 async def list_wine_prices(
     current_user: RequireAuth,
-    skip: int = 0,
-    limit: int = 50,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
 ) -> list[WinePriceSummaryOut]:
     """List wines where the current user has contributed prices."""
-    if limit > 200:
-        limit = 200
     docs = (
         await WinePrice.find({"prices.owner_id": current_user.id})
         .sort([("updated_at", -1)])
@@ -331,16 +329,19 @@ async def delete_price_entry(
 async def get_wine_price_history(
     wine_price_id: str,
     current_user: RequireAuth,
-    skip: int = 0,
-    limit: int = 50,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
 ) -> list[WinePriceHistoryEntryOut]:
-    """Get archived price history for a wine."""
+    """Get archived price history for a wine.
+
+    `WinePriceHistory` is a global archive: every contributor's archived
+    entries for a wine are visible here. Mirror the owner-gating used by
+    `_entry_to_out()` so non-owners cannot read other users' granular
+    location (`town_city`, `state_county`) or free-text `notes`.
+    """
     doc = await WinePrice.find_one({"_id": _parse_wine_price_id(wine_price_id)})
     if not doc:
         raise HTTPException(status_code=404, detail="Wine price not found.")
-
-    if limit > 200:
-        limit = 200
 
     history = (
         await WinePriceHistory.find({
@@ -353,27 +354,30 @@ async def get_wine_price_history(
         .limit(limit)
         .to_list()
     )
-    return [
-        WinePriceHistoryEntryOut(
-            id=str(h.id),
-            wine_name=h.wine_name,
-            vintage=h.vintage,
-            wine_type=h.wine_type,
-            timestamp=h.timestamp,
-            source=h.source.value,
-            price=h.price,
-            currency=h.currency,
-            location={
-                "shop_name": h.location.shop_name,
-                "town_city": h.location.town_city,
-                "state_county": h.location.state_county,
-                "country": h.location.country,
-            },
-            notes=h.notes,
-            archived_at=h.archived_at,
+    results: list[WinePriceHistoryEntryOut] = []
+    for h in history:
+        is_owner = h.owner_id is not None and h.owner_id == current_user.id
+        results.append(
+            WinePriceHistoryEntryOut(
+                id=str(h.id),
+                wine_name=h.wine_name,
+                vintage=h.vintage,
+                wine_type=h.wine_type,
+                timestamp=h.timestamp,
+                source=h.source.value,
+                price=h.price,
+                currency=h.currency,
+                location={
+                    "shop_name": h.location.shop_name,
+                    "town_city": h.location.town_city if is_owner else None,
+                    "state_county": h.location.state_county if is_owner else None,
+                    "country": h.location.country,
+                },
+                notes=h.notes if is_owner else None,
+                archived_at=h.archived_at,
+            )
         )
-        for h in history
-    ]
+    return results
 
 
 @router.get("/photos/{filename}")


### PR DESCRIPTION
## Summary

- Redact `town_city`, `state_county`, and `notes` for non-owner entries returned by `GET /api/prices/{id}/history`. Mirrors the owner-gating already applied by `_entry_to_out()` on the active-prices endpoint.
- Tighten `skip`/`limit` validation on `/api/prices` and `/api/prices/{id}/history` using `Query(..., ge=…, le=200)` so negative skips and over-cap limits hard-reject with 422 instead of silently clamping.
- Three new regression tests including a two-user overflow scenario.

Closes the WARNING in `docs/security-reports/2026-04-23.md` #1 and `docs/security-reports/2026-04-24.md` #1 (the PII leak was first reported on 2026-04-14, ~11 days open).

## Test plan

- [x] `WINEBOX_USE_CLAUDE_VISION=false uv run python -m pytest tests/test_price_tracker.py -v` — 38 pass
- [x] `WINEBOX_USE_CLAUDE_VISION=false uv run python -m pytest -q` — 796 pass, 7 skipped
- [ ] Post-merge OAT smoke: two accounts, user A captures a price with notes, overflow by adding 21 prices, user B hits `/history` — `town_city`/`state_county`/`notes` should be `null` for user-A rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)