### PR TITLE
chore(deps): bump posthog pin to >=7.0.0 and replace identify()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # Export dependencies
     "openpyxl>=3.1.0",
     # Analytics
-    "posthog>=3.0.0",
+    "posthog>=7.0.0",
     "cairosvg>=2.9.0",
 ]
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -98,7 +98,8 @@ class TestPostHogService:
                 )
 
     def test_identify_calls_posthog_when_available(self) -> None:
-        """Test identify calls posthog.identify when available."""
+        """identify() emits `$identify` via capture with `$set` properties
+        (PostHog removed the top-level `identify` helper in v6+)."""
         with patch("winebox.services.analytics.settings") as mock_settings:
             mock_settings.posthog_enabled = True
             mock_settings.posthog_api_key = "phc_test_api_key"
@@ -113,9 +114,10 @@ class TestPostHogService:
                 service = PostHogService()
                 service.identify("user_123", {"email": "user@example.com"})
 
-                mock_posthog.identify.assert_called_once_with(
+                mock_posthog.capture.assert_called_once_with(
                     distinct_id="user_123",
-                    properties={"email": "user@example.com"},
+                    event="$identify",
+                    properties={"$set": {"email": "user@example.com"}},
                 )
 
     def test_shutdown_flushes_and_shuts_down_client(self) -> None:
@@ -163,7 +165,7 @@ class TestPostHogService:
                 )
 
     def test_identify_with_none_properties(self) -> None:
-        """Test identify works with None properties."""
+        """None properties → `$set: {}` via capture."""
         with patch("winebox.services.analytics.settings") as mock_settings:
             mock_settings.posthog_enabled = True
             mock_settings.posthog_api_key = "phc_test_api_key"
@@ -178,9 +180,10 @@ class TestPostHogService:
                 service = PostHogService()
                 service.identify("user_123", None)
 
-                mock_posthog.identify.assert_called_once_with(
+                mock_posthog.capture.assert_called_once_with(
                     distinct_id="user_123",
-                    properties={},
+                    event="$identify",
+                    properties={"$set": {}},
                 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1684,19 +1684,18 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.9.3"
+version = "7.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "distro" },
     { name = "python-dateutil" },
     { name = "requests" },
-    { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/06/bcffcd262c861695fbaa74490b872e37d6fc41d3dcc1a43207d20525522f/posthog-7.9.3.tar.gz", hash = "sha256:55f7580265d290936ac4c112a4e2031a41743be4f90d4183ac9f85b721ff13ae", size = 172336, upload-time = "2026-02-18T22:20:24.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e8/e7890dcdacb7297b3f981b86a26b9538a505a0d0a4aa213a038aa1963561/posthog-7.13.0.tar.gz", hash = "sha256:471295afc144972401b02cf96f635bc43f9527e1cde809b30c48a588e326e86a", size = 193170, upload-time = "2026-04-21T09:12:06.507Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/7e/0e06a96823fa7c11ce73920e6ff77e82445db62ac4eae0b6f211edb4c4c2/posthog-7.9.3-py3-none-any.whl", hash = "sha256:2ddcacdef6c4afb124ebfcf27d7be58388943a7e24f8d4a51a52732c9b90bad6", size = 197819, upload-time = "2026-02-18T22:20:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/c3b31ef4482aabeee6741b5404266a294552efbe99f05c3062c93f3f12ce/posthog-7.13.0-py3-none-any.whl", hash = "sha256:ac6096ad18a1f78169fff3356544cf51dcd80786518c8b46e6c1effddda2929e", size = 227397, upload-time = "2026-04-21T09:12:04.952Z" },
 ]
 
 [[package]]
@@ -2797,7 +2796,7 @@ wheels = [
 
 [[package]]
 name = "winebox"
-version = "0.7.55"
+version = "0.7.56"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -2854,7 +2853,7 @@ requires-dist = [
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "posthog", specifier = ">=3.0.0" },
+    { name = "posthog", specifier = ">=7.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },

--- a/winebox/services/analytics.py
+++ b/winebox/services/analytics.py
@@ -108,19 +108,21 @@ class PostHogService:
         distinct_id: str,
         properties: dict[str, Any] | None = None,
     ) -> None:
-        """Identify a user with optional properties.
+        """Attach person properties to a distinct_id.
 
-        Args:
-            distinct_id: Unique identifier for the user.
-            properties: Optional user properties (e.g., email, plan).
+        PostHog removed the top-level `identify()` helper in the v6+
+        Python SDK. The documented replacement is to emit an
+        `$identify` event via `capture()` with the properties wrapped
+        in `$set`; PostHog applies the same person-profile update.
         """
         if not self._ensure_initialized():
             return
 
         try:
-            self._client.identify(
+            self._client.capture(
                 distinct_id=distinct_id,
-                properties=properties or {},
+                event="$identify",
+                properties={"$set": properties or {}},
             )
             if settings.posthog_debug:
                 logger.debug(


### PR DESCRIPTION
## Summary

- `pyproject.toml` pin tightened from `posthog>=3.0.0` to `posthog>=7.0.0`. We already run v7 in practice (resolved via the lockfile) but the floor allowed a clean install to land on v3.
- PostHog removed the top-level `identify()` helper in v6+; `PostHogService.identify()` now uses the documented replacement (`capture(event='\$identify', properties={'\$set': ...})`). Callers unchanged.
- Updated two analytics tests that mocked `posthog.identify(...)`.

Addresses WARNING #2 in `docs/security-reports/2026-04-23.md`.

## Test plan

- [x] `uv run python -m pytest tests/test_analytics.py -v` — 14 pass
- [x] `uv run python -m pytest -q` — 793 pass, 7 skipped
- [ ] Post-deploy: confirm PostHog dashboard is still receiving \$identify events for new registrations (watch for \`user_registered\` and the person-property update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)