### PR TITLE
fix: Repair stale E2E assertions for cellar tabs and wine-modal timeout

### DIFF
--- a/tests/test_cellar_e2e.py
+++ b/tests/test_cellar_e2e.py
@@ -37,11 +37,15 @@ class TestCellarPage:
     """E2E tests for the cellar page tab structure."""
 
     def test_cellar_has_tab_bar(self, authenticated_page: Page) -> None:
-        """Tab bar with Dashboard/Search/Import/History is present."""
+        """Tab bar with Dashboard/Search/Import/Export/History is present."""
         _navigate_to_cellar(authenticated_page)
         expect(authenticated_page.locator("#cellar-tabs")).to_be_visible()
         tabs = authenticated_page.locator(".cellar-tab")
-        assert tabs.count() == 4
+        assert tabs.count() == 5
+        labels = [tabs.nth(i).inner_text().strip() for i in range(tabs.count())]
+        assert labels == ["Dashboard", "Search", "Import", "Export", "History"], (
+            f"unexpected cellar tab labels: {labels}"
+        )
 
     def test_cellar_dashboard_tab_active_by_default(self, authenticated_page: Page) -> None:
         """Dashboard tab is active by default."""

--- a/tests/test_import_xwines_e2e.py
+++ b/tests/test_import_xwines_e2e.py
@@ -377,11 +377,14 @@ class TestXWinesImport:
         wine_cards = page.locator(".wine-card").all()
         assert len(wine_cards) > 0, "No wine cards found in search results"
 
-        # Spot-check wine detail modal
+        # Spot-check wine detail modal. The modal opens after several
+        # sequential API calls (wine + bottles + cases), so use a 10s
+        # timeout to match other tests opening the same #wine-modal
+        # (e.g. test_case_actions_e2e.py).
         page.locator(".wine-card").first.click()
-        page.wait_for_selector(".modal.active", state="visible", timeout=5000)
+        page.wait_for_selector("#wine-modal.active", state="visible", timeout=10000)
 
-        modal = page.locator(".modal.active")
+        modal = page.locator("#wine-modal.active")
         modal_text = modal.text_content() or ""
 
         # Get the first wine card's title for matching

--- a/uv.lock
+++ b/uv.lock
@@ -2796,7 +2796,7 @@ wheels = [
 
 [[package]]
 name = "winebox"
-version = "0.7.65"
+version = "0.7.67"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary
- Both failures surfaced in the post-design-system OAT E2E run but neither is caused by the design-system PR — they're pre-existing test rot. The do-deployer agent misattributed them; verified with \`git log -S\` / \`git blame\`.
- \`test_cellar_has_tab_bar\` expected 4 tabs; the Export tab was added in [292c2c5](https://github.com/jdrumgoole/winebox/commit/292c2c5) and the test never updated. Bumped to 5 and added an exact label-list assertion so future tab additions/reorders fail loudly.
- \`test_full_import_and_cellar_validation\` waited 5s for \`.modal.active\` after a click that triggers several sequential API calls. Other tests opening the same \`#wine-modal\` already use 10s (\`test_case_actions_e2e.py:69\`). Matched that and tightened the selector to \`#wine-modal.active\`.

## Test plan
- [x] \`uv run python -m pytest tests/ -m "not e2e"\` — 806 unit tests pass
- [x] \`uv run python -m invoke test-e2e-oat\` — 145 E2E tests pass against OAT (was 143 / 2 failed before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)