### PR TITLE
fix: Move theme toggle wiring to external JS files for CSP

### DIFF
--- a/tests/test_design_system_visual.py
+++ b/tests/test_design_system_visual.py
@@ -33,6 +33,67 @@ ARTIFACTS = PROJECT_DIR / "artifacts" / "design-system-visual"
 
 
 @pytest.mark.e2e
+def test_design_system_theme_toggle_button_works(page: Page) -> None:
+    """Click the showcase theme toggle and verify data-theme actually flips.
+
+    Regression guard for CSP-blocked inline scripts: the visual tests below
+    set localStorage via add_init_script, which bypasses the button. So if
+    the toggle's wiring is blocked by CSP, those tests still pass while the
+    user-facing button does nothing.
+    """
+    page.goto(f"{BASE_URL}/design-system", wait_until="networkidle")
+    html = page.locator("html")
+
+    assert html.get_attribute("data-theme") in (None, ""), (
+        "expected no data-theme initially (auto), "
+        f"got {html.get_attribute('data-theme')!r}"
+    )
+
+    btn = page.locator("#ds-theme-toggle")
+    btn.wait_for(state="visible", timeout=3000)
+
+    btn.click()
+    page.wait_for_function(
+        "document.documentElement.getAttribute('data-theme') === 'dark'",
+        timeout=2000,
+    )
+
+    btn.click()
+    page.wait_for_function(
+        "document.documentElement.getAttribute('data-theme') === 'light'",
+        timeout=2000,
+    )
+
+    btn.click()
+    page.wait_for_function(
+        "document.documentElement.getAttribute('data-theme') === null",
+        timeout=2000,
+    )
+
+
+@pytest.mark.e2e
+def test_design_system_no_csp_violations(page: Page) -> None:
+    """Loading /design-system must produce zero CSP violations.
+
+    Catches new inline <script> blocks or onclick= attributes that would
+    be silently blocked by the project CSP.
+    """
+    violations: list[str] = []
+
+    def on_msg(msg) -> None:  # type: ignore[no-untyped-def]
+        text = msg.text or ""
+        if msg.type == "error" and "Content Security Policy" in text:
+            violations.append(text)
+
+    page.on("console", on_msg)
+    page.goto(f"{BASE_URL}/design-system", wait_until="networkidle")
+    page.locator("[data-toast]").first.click()
+    page.wait_for_timeout(200)
+
+    assert not violations, "CSP violations on /design-system: " + " | ".join(violations)
+
+
+@pytest.mark.e2e
 @pytest.mark.parametrize("theme", ["light", "dark"])
 def test_design_system_full_page(page: Page, theme: str) -> None:
     """Render /design-system in `theme` and write a full-page PNG artifact."""

--- a/uv.lock
+++ b/uv.lock
@@ -2796,7 +2796,7 @@ wheels = [
 
 [[package]]
 name = "winebox"
-version = "0.7.67"
+version = "0.7.68"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/winebox/static/design-system.html
+++ b/winebox/static/design-system.html
@@ -6,20 +6,11 @@
     <title>Design System · WineBox</title>
     <link rel="icon" href="/static/logos/favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/static/css/style.css?v=0.7.65">
-    <script>
-        // Apply saved theme before anything paints, to avoid a flash of the wrong theme.
-        (function () {
-            try {
-                var t = localStorage.getItem('wb-theme');
-                if (t === 'dark' || t === 'light') {
-                    document.documentElement.setAttribute('data-theme', t);
-                }
-            } catch (e) { /* localStorage unavailable */ }
-        })();
-    </script>
-    <script src="/static/js/theme.js?v=0.7.65"></script>
-    <script src="/static/js/toast.js?v=0.7.65" defer></script>
+    <link rel="stylesheet" href="/static/css/style.css?v=0.7.68">
+    <!-- theme.js is synchronous and self-applies the saved theme before paint. -->
+    <script src="/static/js/theme.js?v=0.7.68"></script>
+    <script src="/static/js/toast.js?v=0.7.68" defer></script>
+    <script src="/static/js/design-system-page.js?v=0.7.68" defer></script>
     <style>
         /* Showcase-only layout helpers — not part of the design system */
         body { background: var(--background-color); }
@@ -102,21 +93,6 @@
             </nav>
         </div>
     </header>
-    <script>
-        // Showcase theme toggle — wires the button to WineBox.theme.cycle().
-        document.addEventListener('DOMContentLoaded', function () {
-            if (!window.WineBox || !window.WineBox.theme) return;
-            var btn = document.getElementById('ds-theme-toggle');
-            var label = document.getElementById('ds-theme-toggle-label');
-            if (!btn) return;
-            function render(theme) {
-                if (label) label.textContent = 'Theme: ' + theme;
-            }
-            render(window.WineBox.theme.get());
-            window.WineBox.theme.subscribe(render);
-            btn.addEventListener('click', function () { window.WineBox.theme.cycle(); });
-        });
-    </script>
 
     <main class="ds-main">
         <section class="ds-section" style="border: none;">
@@ -464,13 +440,13 @@
                 <h3>Trigger a toast</h3>
                 <p class="ds-type-meta" style="margin-bottom:0.75rem;">Click any button below — the toast appears top-right (or bottom on mobile). Toasts stack and dismiss on click of the &times; or after their timeout.</p>
                 <div class="ds-row">
-                    <button class="btn btn-primary btn-small" type="button" onclick="WineBox.toast.success('Bottle added to your cellar.')">success</button>
-                    <button class="btn btn-secondary btn-small" type="button" onclick="WineBox.toast.warning('Vintage looks unusual', { title: 'Double-check' })">warning</button>
-                    <button class="btn btn-danger btn-small" type="button" onclick="WineBox.toast.error('Couldn\u2019t import \u2014 three rows missing a wine name.', { title: 'Import failed' })">error (sticky)</button>
-                    <button class="btn btn-outline btn-small" type="button" onclick="WineBox.toast.info('Tip \u2014 drag a photo onto the scan area to skip the file picker.')">info</button>
+                    <button class="btn btn-primary btn-small" type="button" data-toast='{"variant":"success","body":"Bottle added to your cellar."}'>success</button>
+                    <button class="btn btn-secondary btn-small" type="button" data-toast='{"variant":"warning","title":"Double-check","body":"Vintage looks unusual"}'>warning</button>
+                    <button class="btn btn-danger btn-small" type="button" data-toast='{"variant":"error","title":"Import failed","body":"Couldn\u2019t import \u2014 three rows missing a wine name."}'>error (sticky)</button>
+                    <button class="btn btn-outline btn-small" type="button" data-toast='{"variant":"info","body":"Tip \u2014 drag a photo onto the scan area to skip the file picker."}'>info</button>
                 </div>
                 <div class="ds-row" style="margin-top:1rem;">
-                    <button class="btn btn-secondary btn-small" type="button" onclick="WineBox.toast.success('Saved'); WineBox.toast.info('Updated 2 minutes ago'); WineBox.toast.warning('1 row needs review');">stack three</button>
+                    <button class="btn btn-secondary btn-small" type="button" data-toast='[{"variant":"success","body":"Saved"},{"variant":"info","body":"Updated 2 minutes ago"},{"variant":"warning","body":"1 row needs review"}]'>stack three</button>
                 </div>
             </div>
 

--- a/winebox/static/index.html
+++ b/winebox/static/index.html
@@ -31,17 +31,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/logos/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/static/logos/apple-touch-icon.png">
     <link rel="stylesheet" href="/static/css/style.css?v=0.7.68">
-    <!-- Theme: apply saved preference before paint to avoid flash of wrong theme -->
-    <script>
-        (function () {
-            try {
-                var t = localStorage.getItem('wb-theme');
-                if (t === 'dark' || t === 'light') {
-                    document.documentElement.setAttribute('data-theme', t);
-                }
-            } catch (e) { /* localStorage unavailable */ }
-        })();
-    </script>
+    <!-- theme.js is synchronous and self-applies the saved theme before paint. -->
     <script src="/static/js/theme.js?v=0.7.68"></script>
     <script src="/static/js/chart.min.js"></script>
     <!-- PostHog Analytics Configuration -->
@@ -1667,32 +1657,6 @@
     <script src="/static/js/papaparse.min.js?v=0.7.68"></script>
     <script src="/static/js/toast.js?v=0.7.68"></script>
     <script src="/static/js/app.js?v=0.7.68"></script>
-    <script>
-        // Wire the theme toggle in the header to WineBox.theme.cycle().
-        (function () {
-            var btn = document.getElementById('theme-toggle');
-            if (!btn || !window.WineBox || !window.WineBox.theme) return;
-            var icons = {
-                auto:  btn.querySelector('.theme-icon-auto'),
-                light: btn.querySelector('.theme-icon-light'),
-                dark:  btn.querySelector('.theme-icon-dark')
-            };
-            var labels = {
-                auto:  'Theme: follow system (click to switch)',
-                light: 'Theme: light (click to switch)',
-                dark:  'Theme: dark (click to switch)'
-            };
-            function render(theme) {
-                Object.keys(icons).forEach(function (k) {
-                    if (icons[k]) icons[k].style.display = (k === theme) ? '' : 'none';
-                });
-                btn.title = labels[theme] || labels.auto;
-                btn.setAttribute('aria-label', labels[theme] || labels.auto);
-            }
-            render(window.WineBox.theme.get());
-            window.WineBox.theme.subscribe(render);
-            btn.addEventListener('click', function () { window.WineBox.theme.cycle(); });
-        })();
-    </script>
+    <script src="/static/js/theme-toggle.js?v=0.7.68"></script>
 </body>
 </html>

--- a/winebox/static/js/design-system-page.js
+++ b/winebox/static/js/design-system-page.js
@@ -1,0 +1,63 @@
+/* Design-system showcase page wiring (CSP-compliant — no inline scripts).
+
+   Powers two things on /design-system:
+   - the auto/dark/light theme toggle in the showcase header
+   - the toast trigger buttons (data-toast="<json>") in the toasts section
+*/
+(function () {
+    'use strict';
+
+    function wireThemeToggle() {
+        if (!window.WineBox || !window.WineBox.theme) return;
+        var btn = document.getElementById('ds-theme-toggle');
+        var label = document.getElementById('ds-theme-toggle-label');
+        if (!btn) return;
+
+        function render(theme) {
+            if (label) label.textContent = 'Theme: ' + theme;
+        }
+
+        render(window.WineBox.theme.get());
+        window.WineBox.theme.subscribe(render);
+        btn.addEventListener('click', function () { window.WineBox.theme.cycle(); });
+    }
+
+    function wireToastDemos() {
+        if (!window.WineBox || !window.WineBox.toast) return;
+        document.querySelectorAll('[data-toast]').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var spec;
+                try {
+                    spec = JSON.parse(btn.getAttribute('data-toast'));
+                } catch (e) {
+                    return;
+                }
+                if (Array.isArray(spec)) {
+                    spec.forEach(showOne);
+                } else {
+                    showOne(spec);
+                }
+            });
+        });
+    }
+
+    function showOne(spec) {
+        var variant = spec && spec.variant;
+        var fn = window.WineBox.toast[variant] || window.WineBox.toast.show;
+        var opts = {};
+        if (spec.title) opts.title = spec.title;
+        if (spec.duration !== undefined) opts.duration = spec.duration;
+        fn(spec.body || '', opts);
+    }
+
+    function init() {
+        wireThemeToggle();
+        wireToastDemos();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/winebox/static/js/theme-toggle.js
+++ b/winebox/static/js/theme-toggle.js
@@ -1,0 +1,43 @@
+/* WineBox theme toggle wiring for the main app header.
+   Pairs the #theme-toggle button (in index.html) with WineBox.theme.cycle().
+   Loaded after theme.js so window.WineBox.theme is available.
+
+   Kept in an external file (not inline) for CSP compliance — the project
+   CSP forbids inline <script> blocks. */
+(function () {
+    'use strict';
+
+    function init() {
+        var btn = document.getElementById('theme-toggle');
+        if (!btn || !window.WineBox || !window.WineBox.theme) return;
+
+        var icons = {
+            auto: btn.querySelector('.theme-icon-auto'),
+            light: btn.querySelector('.theme-icon-light'),
+            dark: btn.querySelector('.theme-icon-dark')
+        };
+        var labels = {
+            auto: 'Theme: follow system (click to switch)',
+            light: 'Theme: light (click to switch)',
+            dark: 'Theme: dark (click to switch)'
+        };
+
+        function render(theme) {
+            Object.keys(icons).forEach(function (k) {
+                if (icons[k]) icons[k].style.display = (k === theme) ? '' : 'none';
+            });
+            btn.title = labels[theme] || labels.auto;
+            btn.setAttribute('aria-label', labels[theme] || labels.auto);
+        }
+
+        render(window.WineBox.theme.get());
+        window.WineBox.theme.subscribe(render);
+        btn.addEventListener('click', function () { window.WineBox.theme.cycle(); });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Summary
- The dark-mode toggle did nothing on OAT/production because the project CSP \`script-src 'self'\` silently blocked every inline \`<script>\` block I added with the design system. \`CLAUDE.md\` already says \"No inline scripts — use external JS files for CSP compliance.\" I missed it.
- New \`theme-toggle.js\` handles the index.html header button. New \`design-system-page.js\` handles the showcase (theme cycle + toast triggers via \`data-toast='<json>'\` instead of \`onclick\`).
- Pre-paint inline script removed — \`theme.js\` loads synchronously in \`<head>\` and already self-applies the saved theme before first paint.

## Regression guards (new tests)
- \`test_design_system_theme_toggle_button_works\` — actually clicks the toggle and asserts \`data-theme\` cycles dark / light / null. The visual tests used \`add_init_script\` to set localStorage, bypassing the button entirely, which is why the breakage shipped.
- \`test_design_system_no_csp_violations\` — listens for \`Content Security Policy\` console errors when loading \`/design-system\` and clicking a toast trigger; fails on any new inline-script or inline-handler regression.

## Test plan
- [x] \`uv run python -m pytest tests/ -m \"not e2e\"\` — 806 unit tests pass
- [x] Both new E2E tests pass against a local server (same CSP as OAT)
- [ ] After merge + OAT release, verify the toggle button actually changes theme on https://oat.winebox.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)