### PR TITLE
chore: Add static-asset lint to block CSP-violating inline scripts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,18 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python scripts/claude_precommit_lint.py",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(uv run *)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
         run: uv run pip install isort && uv run isort --check-only --diff winebox tests
         continue-on-error: true
 
+      - name: Lint static assets (CSP — no inline scripts / onclick handlers)
+        run: uv run python scripts/lint_static_assets.py
+
   build:
     name: Build package
     runs-on: ubuntu-latest

--- a/scripts/claude_precommit_lint.py
+++ b/scripts/claude_precommit_lint.py
@@ -1,0 +1,68 @@
+"""Claude Code PreToolUse hook — block `git commit` when static-asset lint fails.
+
+Wired up in .claude/settings.json under PreToolUse for the Bash tool. The
+harness invokes this on every Bash call with the tool payload on stdin.
+The script no-ops for any command other than `git commit`; for commits it
+runs scripts/lint_static_assets.py and refuses the tool call if any rule
+fires (non-zero exit code is what Claude Code uses to block).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def is_git_commit(cmd: str) -> bool:
+    """Return True if ``cmd`` invokes ``git commit`` somewhere in the line.
+
+    Matches the bare command, chained shell forms (``&& git commit``,
+    ``; git commit``), and grouped forms (``( ... ) && git commit``).
+    Avoids matching strings like ``git commit-tree`` or comments.
+    """
+    if not cmd:
+        return False
+    # Normalise whitespace so we can do simple token matching.
+    tokens = cmd.replace("&&", " ").replace("||", " ").replace(";", " ").split()
+    for i, tok in enumerate(tokens):
+        if tok == "git" and i + 1 < len(tokens) and tokens[i + 1] == "commit":
+            return True
+    return False
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # Don't block when we can't parse the payload.
+
+    cmd = (payload.get("tool_input") or {}).get("command", "") or ""
+    if not is_git_commit(cmd):
+        return 0
+
+    repo_root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            str(repo_root / "scripts" / "lint_static_assets.py"),
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        # Surface a helpful message in the hook output so the model and the
+        # user both see why the commit was refused.
+        print(
+            "\nstatic-asset lint refused the commit. "
+            "Fix the violations above (move inline scripts/handlers to "
+            "external JS files) and try again.",
+            file=sys.stderr,
+        )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_static_assets.py
+++ b/scripts/lint_static_assets.py
@@ -1,0 +1,128 @@
+"""Static-asset lint — fails the build on patterns that break in production.
+
+Each rule guards an actual past incident, not a stylistic preference. New
+rules belong here when a regression slips past code review and we want a
+mechanical check that prevents the same class of bug from re-shipping.
+
+Run:
+    uv run python scripts/lint_static_assets.py
+
+Exits with code 0 on a clean tree, code 1 if any rule fires.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# Files outside this list are not scanned. Keep the surface small so the
+# rules stay focused on user-facing static assets.
+HTML_FILES: tuple[str, ...] = (
+    "winebox/static/index.html",
+    "winebox/static/landing.html",
+    "winebox/static/design-system.html",
+    "winebox/static/price-tracker.html",
+)
+
+# Regex that flags a non-empty <script> block (i.e. an inline script body),
+# but allows <script src="..."> tags. Matches when <script ...> is followed
+# by anything other than whitespace and an immediate </script>.
+INLINE_SCRIPT_RE = re.compile(
+    r"<script(?![^>]*\bsrc=)[^>]*>(?!\s*</script>)",
+    re.IGNORECASE,
+)
+
+# Inline event handlers: on*="..." attributes. The leading whitespace is
+# required so we don't match e.g. attribute names that happen to contain
+# "on" in the middle.
+INLINE_HANDLER_RE = re.compile(
+    r"\son\w+\s*=\s*\"",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    file: Path
+    line: int
+    rule: str
+    snippet: str
+
+    def format(self) -> str:
+        return f"{self.file}:{self.line}: [{self.rule}] {self.snippet.strip()}"
+
+
+def scan_file(path: Path) -> list[Violation]:
+    """Return every violation found in ``path``."""
+    if not path.exists():
+        return []
+
+    violations: list[Violation] = []
+    for line_no, line in enumerate(path.read_text().splitlines(), start=1):
+        if INLINE_SCRIPT_RE.search(line):
+            violations.append(
+                Violation(
+                    file=path,
+                    line=line_no,
+                    rule="inline-script",
+                    snippet=line[:200],
+                )
+            )
+        if INLINE_HANDLER_RE.search(line):
+            violations.append(
+                Violation(
+                    file=path,
+                    line=line_no,
+                    rule="inline-handler",
+                    snippet=line[:200],
+                )
+            )
+    return violations
+
+
+def scan(repo_root: Path, files: Iterable[str]) -> list[Violation]:
+    """Run every rule across ``files`` and return all violations."""
+    out: list[Violation] = []
+    for rel in files:
+        out.extend(scan_file(repo_root / rel))
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repository root (defaults to the parent of this script).",
+    )
+    args = parser.parse_args()
+
+    violations = scan(args.root, HTML_FILES)
+    if not violations:
+        print("static-asset lint: clean")
+        return 0
+
+    print(f"static-asset lint: {len(violations)} violation(s)\n")
+    print("Why each rule exists:")
+    print(
+        "  inline-script   The project's CSP forbids inline <script>. "
+        "Browsers silently block them, so they ship as broken features. "
+        "Move the body to a /static/js/*.js file and load it with src=."
+    )
+    print(
+        "  inline-handler  Inline on*= attributes are also CSP-blocked. "
+        "Replace with addEventListener wired up from an external script."
+    )
+    print()
+    for v in violations:
+        print(v.format())
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -2796,7 +2796,7 @@ wheels = [
 
 [[package]]
 name = "winebox"
-version = "0.7.68"
+version = "0.7.69"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/winebox/static/design-system.html
+++ b/winebox/static/design-system.html
@@ -286,7 +286,7 @@
             <p class="ds-lede">Every input has a visible label. Focus state is burgundy border + soft glow — never suppress it.</p>
 
             <div class="ds-demo">
-                <form class="form-grid" onsubmit="event.preventDefault()">
+                <form id="ds-form-demo" class="form-grid">
                     <div class="form-group">
                         <label for="ds-wine">Wine name</label>
                         <input id="ds-wine" type="text" placeholder="Château Margaux">

--- a/winebox/static/js/design-system-page.js
+++ b/winebox/static/js/design-system-page.js
@@ -50,9 +50,16 @@
         fn(spec.body || '', opts);
     }
 
+    function wireFormDemo() {
+        var form = document.getElementById('ds-form-demo');
+        if (!form) return;
+        form.addEventListener('submit', function (e) { e.preventDefault(); });
+    }
+
     function init() {
         wireThemeToggle();
         wireToastDemos();
+        wireFormDemo();
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
Two mechanical guards so the CSP-blocked-toggle bug from PR #28 can't ship again:

- **\`scripts/lint_static_assets.py\`** — walks the four served HTML files (index, landing, design-system, price-tracker) and fails on any inline \`<script>\` body or inline \`on*=\` handler. Each rule prints _why_ so the failure mode is self-explanatory.
- **CI** — wired into the existing Lint job in \`.github/workflows/ci.yml\`. PRs fail if anyone reintroduces the pattern.
- **Claude Code hook** — \`.claude/settings.json\` adds a PreToolUse hook on Bash that intercepts \`git commit\` calls and refuses on lint failure. Catches it mid-session, before CI.

While wiring this up the lint caught a real violation I missed in #28: \`design-system.html\` had \`onsubmit=\"event.preventDefault()\"\` on a demo form. Moved to a submit listener in \`design-system-page.js\`.

## Test plan
- [x] \`uv run python scripts/lint_static_assets.py\` — clean (806 unit tests still pass)
- [x] End-to-end hook test: \`echo '{\"tool_input\":{\"command\":\"git commit -m test\"}}' | uv run python scripts/claude_precommit_lint.py\` exits 0 on a clean tree, exits 1 with a clear message after temporarily injecting \`<script>console.log(\"x\")</script>\` into landing.html
- [ ] CI lint step passes on this PR (will verify once it runs)

## Why bother
PR #28's bug was caused by inline \`<script>\` blocks the CSP silently blocked. The CLAUDE.md rule \"No inline scripts — use external JS files for CSP compliance\" was already in context but wasn't actively cross-checked. The pattern this PR establishes — write a Python lint script, run it in CI _and_ as a Claude Code commit hook — is reusable: future rules (no raw hex outside :root, missing form labels, etc) just add functions to \`lint_static_assets.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)