### PR TITLE
Adopt security review recommendations + password strength feedback

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ This design decision is intentional for several reasons:
 
 The application sets comprehensive security headers:
 
-- `Content-Security-Policy` with nonces for inline scripts
+- `Content-Security-Policy` with strict whitelist (`script-src 'self'`, no inline scripts allowed)
 - `X-Frame-Options: DENY`
 - `X-Content-Type-Options: nosniff`
 - `Referrer-Policy: strict-origin-when-cross-origin`

--- a/deploy/nginx-winebox-oat.conf
+++ b/deploy/nginx-winebox-oat.conf
@@ -66,6 +66,8 @@ server {
         alias /opt/winebox/static/index.html;
         expires 5m;
         add_header Cache-Control "public, must-revalidate";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Static assets (CSS, JS, images, fonts) - long cache with versioned URLs
@@ -75,6 +77,8 @@ server {
         expires 30d;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Favicon
@@ -83,6 +87,8 @@ server {
         expires 30d;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Admin panel - IP restricted (matches prod hardening). Add the operator IP

--- a/deploy/nginx-winebox.conf
+++ b/deploy/nginx-winebox.conf
@@ -89,6 +89,8 @@ server {
         alias /opt/winebox/static/landing.html;
         expires 5m;
         add_header Cache-Control "public, must-revalidate";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Static assets (CSS, JS, images, fonts) - long cache with versioned URLs
@@ -99,6 +101,8 @@ server {
         expires 30d;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # CSS files
@@ -107,6 +111,8 @@ server {
         expires 30d;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Favicon (SVG)
@@ -114,6 +120,8 @@ server {
         alias /opt/winebox/static/favicon.svg;
         expires 30d;
         add_header Content-Type "image/svg+xml";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Legacy favicon.ico redirect to SVG
@@ -182,6 +190,8 @@ server {
         alias /opt/winebox/static/index.html;
         expires 5m;
         add_header Cache-Control "public, must-revalidate";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Static assets (CSS, JS, images, fonts) - long cache with versioned URLs
@@ -192,6 +202,8 @@ server {
         expires 30d;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Favicon
@@ -200,6 +212,8 @@ server {
         expires 30d;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=63072000" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # Admin panel - IP restricted

--- a/tasks.py
+++ b/tasks.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shlex
 import sys
 import time
 import urllib.request
@@ -276,7 +277,10 @@ def test_e2e_db(
     # Use a fixed secret key so the server and CLI (winebox-admin) share the
     # same JWT signing key.  Without this, the server generates a random key
     # on startup and tokens created by the CLI are rejected.
-    e2e_secret = "e2e-test-secret-key-not-for-production-use-1234567890"
+    e2e_secret = os.environ.get(
+        "WINEBOX_E2E_SECRET_KEY",
+        "e2e-test-secret-key-not-for-production-use-1234567890",
+    )
 
     # Build env for the server subprocess — inherit current env + overrides
     server_env = os.environ.copy()
@@ -534,9 +538,9 @@ def backup(ctx: Context, profile: str = "winebox_backup", database: str | None =
     if not url:
         print("Error: WINEBOX_MONGODB_URL is not set", file=sys.stderr)
         sys.exit(1)
-    cmd = f"uv run python scripts/mongodb_backup.py --profile {profile} backup '{url}'"
+    cmd = f"uv run python scripts/mongodb_backup.py --profile {shlex.quote(profile)} backup {shlex.quote(url)}"
     if database:
-        cmd += f" --database {database}"
+        cmd += f" --database {shlex.quote(database)}"
     ctx.run(cmd, pty=True)
 
 
@@ -587,7 +591,7 @@ def purge_user(ctx: Context, email: str, yes: bool = False) -> None:
         email: Email of user whose data to purge
         yes: Skip confirmation prompt (-y)
     """
-    cmd = f"uv run winebox-purge --user {email}"
+    cmd = f"uv run winebox-purge --user {shlex.quote(email)}"
     if yes:
         cmd += " -y"
     ctx.run(cmd, pty=not yes)
@@ -609,7 +613,7 @@ def add_user(
         password: Password for the new user
         admin: Make user an admin (default: False)
     """
-    cmd = f"uv run winebox-admin add {email} --password {password}"
+    cmd = f"uv run winebox-admin add {shlex.quote(email)} --password {shlex.quote(password)}"
     if admin:
         cmd += " --admin"
     ctx.run(cmd)
@@ -624,7 +628,7 @@ def remove_user(ctx: Context, email: str, force: bool = False) -> None:
         email: Email of user to remove
         force: Skip confirmation prompt
     """
-    cmd = f"uv run winebox-admin remove {email}"
+    cmd = f"uv run winebox-admin remove {shlex.quote(email)}"
     if force:
         cmd += " --force"
     ctx.run(cmd, pty=True)
@@ -644,7 +648,7 @@ def disable_user(ctx: Context, email: str) -> None:
         ctx: Invoke context
         email: Email of user to disable
     """
-    ctx.run(f"uv run winebox-admin disable {email}")
+    ctx.run(f"uv run winebox-admin disable {shlex.quote(email)}")
 
 
 @task(name="enable-user", aliases=["user-enable"])

--- a/winebox/static/css/style.css
+++ b/winebox/static/css/style.css
@@ -2306,6 +2306,51 @@ details.advanced-fields .form-grid {
     margin-top: 0.25rem;
 }
 
+.password-strength {
+    margin-top: 0.4rem;
+}
+
+.password-strength-bar {
+    height: 4px;
+    background: var(--border-color);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.password-strength-fill {
+    height: 100%;
+    width: 0;
+    border-radius: 2px;
+    transition: width 0.3s ease, background-color 0.3s ease;
+}
+
+.password-strength-label {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+}
+
+.password-strength[data-level="weak"] .password-strength-fill {
+    width: 25%;
+    background-color: var(--error-color);
+}
+
+.password-strength[data-level="fair"] .password-strength-fill {
+    width: 50%;
+    background-color: var(--warning-color);
+}
+
+.password-strength[data-level="good"] .password-strength-fill {
+    width: 75%;
+    background-color: var(--success-color);
+}
+
+.password-strength[data-level="strong"] .password-strength-fill {
+    width: 100%;
+    background-color: var(--success-color);
+}
+
 .spinner {
     width: 40px;
     height: 40px;

--- a/winebox/static/index.html
+++ b/winebox/static/index.html
@@ -148,7 +148,10 @@
                                 <svg class="icon eye-off-icon" viewBox="0 0 24 24" aria-hidden="true" style="display: none;"><use href="#i-eye-off"/></svg>
                             </button>
                         </div>
-                        <span class="form-hint">At least 8 characters</span>
+                        <div class="password-strength" id="register-password-strength">
+                            <div class="password-strength-bar"><div class="password-strength-fill"></div></div>
+                            <span class="password-strength-label">At least 8 characters</span>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label for="register-confirm-password">Confirm Password</label>
@@ -201,7 +204,10 @@
                                 <svg class="icon eye-off-icon" viewBox="0 0 24 24" aria-hidden="true" style="display: none;"><use href="#i-eye-off"/></svg>
                             </button>
                         </div>
-                        <span class="form-hint">At least 8 characters</span>
+                        <div class="password-strength" id="reset-password-strength">
+                            <div class="password-strength-bar"><div class="password-strength-fill"></div></div>
+                            <span class="password-strength-label">At least 8 characters</span>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label for="reset-confirm-password">Confirm New Password</label>
@@ -1273,6 +1279,10 @@
                                 <svg class="icon eye-icon" viewBox="0 0 24 24" aria-hidden="true"><use href="#i-eye"/></svg>
                                 <svg class="icon eye-off-icon" viewBox="0 0 24 24" aria-hidden="true" style="display: none;"><use href="#i-eye-off"/></svg>
                             </button>
+                        </div>
+                        <div class="password-strength" id="new-password-strength">
+                            <div class="password-strength-bar"><div class="password-strength-fill"></div></div>
+                            <span class="password-strength-label">At least 8 characters</span>
                         </div>
                     </div>
                     <div class="form-group">

--- a/winebox/static/js/app.js
+++ b/winebox/static/js/app.js
@@ -333,6 +333,7 @@ function initAuth() {
 
     // Password toggle for all password fields
     initPasswordToggles();
+    initPasswordStrengthMeters();
 
     // Registration form
     const registerForm = document.getElementById('register-form');
@@ -401,6 +402,42 @@ function initPasswordToggles() {
                 eyeOffIcon.style.display = 'none';
                 this.setAttribute('aria-label', 'Show password');
             }
+        });
+    });
+}
+
+function scorePassword(password) {
+    if (!password) return { level: '', label: 'At least 8 characters' };
+    if (password.length < 8) return { level: '', label: 'At least 8 characters' };
+
+    let score = 0;
+    if (password.length >= 8) score++;
+    if (password.length >= 12) score++;
+    if (password.length >= 16) score++;
+    if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score++;
+    if (/\d/.test(password)) score++;
+    if (/[^a-zA-Z0-9]/.test(password)) score++;
+
+    if (score <= 2) return { level: 'weak', label: 'Weak — try adding more characters' };
+    if (score <= 3) return { level: 'fair', label: 'Fair — a longer mix would be stronger' };
+    if (score <= 4) return { level: 'good', label: 'Good' };
+    return { level: 'strong', label: 'Strong' };
+}
+
+function initPasswordStrengthMeters() {
+    const fields = [
+        { inputId: 'register-password', meterId: 'register-password-strength' },
+        { inputId: 'reset-password', meterId: 'reset-password-strength' },
+        { inputId: 'new-password', meterId: 'new-password-strength' },
+    ];
+    fields.forEach(({ inputId, meterId }) => {
+        const input = document.getElementById(inputId);
+        const meter = document.getElementById(meterId);
+        if (!input || !meter) return;
+        input.addEventListener('input', () => {
+            const { level, label } = scorePassword(input.value);
+            meter.setAttribute('data-level', level);
+            meter.querySelector('.password-strength-label').textContent = label;
         });
     });
 }
@@ -3734,8 +3771,8 @@ async function handlePasswordChange(e) {
         return;
     }
 
-    if (newPassword.length < 6) {
-        showToast('Password must be at least 6 characters', 'error');
+    if (newPassword.length < 8) {
+        showToast('Password must be at least 8 characters', 'error');
         return;
     }
 


### PR DESCRIPTION
## Summary

Implements all 5 INFO recommendations from the 2026-04-26 security review (PR #30).

- **INFO-1**: Fix SECURITY.md — CSP description claimed nonces but actual strategy is a strict whitelist
- **INFO-2**: Add `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to all nginx static file locations (production + OAT) for defence-in-depth
- **INFO-3**: Add real-time password strength meter to registration, reset, and change password forms (feedback only, no enforcement beyond 8-char minimum)
- **INFO-4**: Use `shlex.quote()` on all user-supplied parameters in invoke task shell commands
- **INFO-5**: Load E2E test secret key from `WINEBOX_E2E_SECRET_KEY` env var with fallback

Also fixes password change handler checking for 6 characters instead of 8 (inconsistent with registration).

https://claude.ai/code/session_01LjhiogDmxxPR3sbwsm9WLz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjhiogDmxxPR3sbwsm9WLz)_