### PR TITLE
Security Review — 2026-04-27 (security-warning)

### DIFF
--- a/docs/security-reports/2026-04-27.md
+++ b/docs/security-reports/2026-04-27.md
@@ -1,0 +1,235 @@
+# Security Review — 2026-04-27
+
+## Scope
+
+Comprehensive daily security audit of the WineBox project (FastAPI + MongoDB wine cellar application) covering:
+
+1. Dependency vulnerability check
+2. Hardcoded secrets scan
+3. Authentication & authorization audit
+4. NoSQL injection & input validation audit
+5. Rate limiting & DoS prevention
+6. Session & token security
+7. Security headers & CORS
+8. Data exposure review
+9. Git history review
+10. Infrastructure & configuration
+11. Third-party integration security
+
+---
+
+## Findings
+
+### 🟠 WARNING
+
+**WARN-1: XSS in static site export filter summary**
+
+- **File:** `winebox/services/export_service/static_site_template.py` (lines 30–34)
+- **Detail:** User-supplied search filter values (e.g., `country`, `grape`, `winery` query parameters from `GET /api/export/static-site`) are embedded directly into the exported HTML page without HTML escaping. An attacker could craft a URL like `/api/export/static-site?country=<img src=x onerror=alert(1)>` and the resulting ZIP download would contain an HTML file with executable JavaScript.
+- **Attack vector:** The victim must be tricked into exporting their cellar with a malicious filter, then opening the exported HTML. This is a stored-XSS-in-export scenario — the XSS payload lives in the downloaded file, not on the WineBox server itself.
+- **Impact:** Moderate. The export is a self-contained offline file; the attacker cannot steal session tokens from `booze.winebox.app` because the file is opened from `file://` or a different origin. However, a crafted export could run arbitrary JS in the victim's browser context.
+- **Recommendation:** Use `html.escape()` on all filter values before embedding them in the HTML template:
+  ```python
+  import html
+  parts = [f"{html.escape(k)}: {html.escape(v)}" for k, v in filters_applied.items() if v]
+  ```
+
+---
+
+### 🟡 INFO (Best practice recommendations)
+
+**INFO-1: `list_batches` endpoint accepts uncapped `limit` parameter**
+
+- **File:** `winebox/routers/import_router.py` (line 509)
+- **Detail:** The `GET /api/import/batches` endpoint accepts an optional `limit: int | None` parameter without a maximum cap. When `limit` is not provided, the query runs without any `.limit()` call at all. Since this is scoped to `owner_id`, the practical risk is low (a user can only load their own batch history), but it violates the project's defence-in-depth pattern where all list endpoints cap results via `MAX_PAGE_SIZE` or `MAX_USER_RESULTSET`.
+- **Recommendation:** Add `Query(default=100, ge=1, le=MAX_PAGE_SIZE)` to enforce a ceiling, consistent with other endpoints.
+
+**INFO-2: E2E test secret key hardcoded in tasks.py**
+
+- **File:** `tasks.py` (lines 282, 1771)
+- **Values:** `"e2e-test-secret-key-not-for-production-use-1234567890"` and `"oat-e2e-test-secret-key-1234567890"`
+- **Detail:** Clearly labelled test-only values used for isolated E2E test environments. Not used in production. Low risk, but inconsistent with the project guideline to read all secrets from environment variables.
+- **Recommendation:** Consider loading from an environment variable with a fallback for consistency.
+
+**INFO-3: Reference data endpoints have unbounded `to_list()` calls**
+
+- **File:** `winebox/routers/reference.py` (multiple endpoints)
+- **Detail:** Endpoints like `GET /api/reference/grape-varieties`, `GET /api/reference/regions`, and `GET /api/reference/classifications` call `.to_list()` without a `length=` limit. These are public read-only reference data endpoints with bounded dataset sizes (wine types ~20, grapes ~200, regions ~3000, classifications ~500), so the risk is low. However, if the reference dataset grows unexpectedly, these could become memory-intensive.
+- **Recommendation:** Add explicit `length=` bounds matching the expected dataset sizes, e.g., `.to_list(length=5000)`.
+
+---
+
+### 🟢 CLEAN (Passed review)
+
+#### 1. Dependency Vulnerability Check
+
+All key dependencies are at patched versions:
+
+| Package | Locked Version | Status |
+|---------|---------------|--------|
+| fastapi | 0.128.1 | Current, no known CVEs |
+| uvicorn | 0.40.0 | Current, no known CVEs |
+| pydantic | 2.12.5 | Current, no known CVEs |
+| pymongo | 4.16.0 | Current, no known CVEs |
+| pillow | 12.2.0 | Patched for CVE-2026-25990 and CVE-2026-40192 |
+| python-multipart | 0.0.26 | Patched for CVE-2026-40347 |
+| jinja2 | 3.1.6 | Current, no known CVEs |
+| bcrypt | 5.0.0 | Current, no known CVEs |
+| pyjwt | 2.12.1 | Patched for CVE-2026-32597 (crit header bypass) |
+| cryptography | 46.0.7 | Patched for CVE-2026-39892 and CVE-2026-34073 |
+| anthropic | 0.96.0 | Current (CVE-2026-34450/34452 affect memory tool, not used by WineBox) |
+| slowapi | 0.1.9 | Current, no known CVEs |
+| openpyxl | 3.1.5 | Current, no known CVEs |
+| posthog | 7.13.0 | Current, no known CVEs |
+| cairosvg | 2.9.0 | Patched for CVE-2026-31899 (recursive use DoS) |
+| aioboto3 | 15.5.0 | Current, no known CVEs |
+| httpx | 0.28.1 | Current, no known CVEs |
+| fastapi-users | 15.0.4 | Current, no known CVEs |
+| pydantic-settings | 2.12.0 | Current, no known CVEs |
+
+No dependencies are yanked or more than 2 major versions behind.
+
+#### 2. Hardcoded Secrets Scan
+
+- No API keys, connection strings, passwords, private keys, or JWTs found in source code.
+- `config/secrets.env.example` contains only placeholder values.
+- `.gitignore` properly covers: `.env`, `secrets.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- `git ls-files` confirms no sensitive files tracked (only `config/secrets.env.example`).
+- Test fixtures use obvious dummy values (`sk-ant-api-key`, `phc_test_api_key`).
+- GitHub Actions workflows use `${{ secrets.NAME }}` pattern throughout.
+- Deployment scripts generate secrets dynamically or load from environment.
+
+#### 3. Authentication & Authorization Audit
+
+- **All 60+ endpoints** handling user data require `RequireAuth` or `RequireAdmin`.
+- **All database queries** for user-owned data filter by `owner_id` or `cellar_id`.
+- Public endpoints (`/api/reference/*`, `/api/xwines/*`, `/health`, `/api/config/analytics`) serve only static reference data — no user information exposed.
+- Admin endpoints use `RequireAdmin` (not just `RequireAuth`). Admin panel IP-restricted in nginx.
+- Password changes invalidate all existing tokens via dual mechanism:
+  - Per-token blacklist (JTI-based)
+  - Bulk `tokens_invalidated_after` cutoff on user document
+- User registration validates email format (Pydantic `EmailStr`) and password length (8+ chars).
+- Constant-time password comparison via Argon2 `verify()` with dummy hash for non-existent users.
+- Password strength feedback implemented in the UI (visual meter with actionable advice).
+
+#### 4. NoSQL Injection & Query Safety
+
+- All regex searches use `re.escape()` before compilation.
+- No unsafe MongoDB operators (`$where`, `$expr`, `$accumulator`, `$function`) found.
+- All `ObjectId` parsing wrapped in `try/except` with proper 400/404 responses.
+- All API inputs validated via Pydantic models — no raw `dict` or untyped JSON bodies.
+- No raw pymongo collection access bypassing model safety.
+- Search query length capped at 200 characters.
+
+#### 5. Input Validation & Injection Prevention
+
+- File uploads validated: magic byte detection, extension whitelist, size limits (image 10 MB, import 25 MB).
+- Path traversal prevented in image serving (`_safe_resolve()` rejects `..` components).
+- Generated filenames use UUIDs, not user input.
+- Jinja2 templates use `autoescape=True` — no `|safe` or `{% autoescape false %}` usage.
+- No `eval()`, `exec()`, `__import__()`, or `compile()` in application code.
+- All paginated endpoints enforce maximum limits via `Query(ge=1, le=MAX)`.
+
+#### 6. Rate Limiting & DoS Prevention
+
+- **Global:** 60 requests/minute per IP.
+- **Login:** 30/minute, 200/hour + account lockout after 5 failed attempts (15-minute window).
+- **Registration:** 10/minute, 50/hour.
+- **Password reset/change:** 5/minute, 20/hour.
+- **Search:** 120/minute, 2000/hour with 200-char query limit.
+- **Export:** 10/minute, 30/hour.
+- **Scan/enrichment:** 20/minute, 100–200/hour.
+- **Price captures:** 30/minute, 200/hour.
+- **Demo install:** 5/minute, 10/hour.
+- All paginated queries bounded by `MAX_USER_RESULTSET` (10,000) or `MAX_REFERENCE_RESULTSET` (5,000).
+
+#### 7. Session & Token Security
+
+- JWT tokens use HS256 with minimum 32-character secret key (enforced at startup).
+- Tokens include `jti` (UUID), `iat`, `exp`, and `sub` claims.
+- Dual-layer revocation: per-token blacklist + bulk user invalidation cutoff.
+- Expired token cleanup via background task (hourly).
+- Purpose-specific secret derivation (SHA256) for reset/verification tokens prevents type confusion.
+- No token values logged anywhere in the codebase.
+- HSTS enabled in production: `max-age=63072000; includeSubDomains`.
+
+#### 8. Security Headers
+
+- `X-Content-Type-Options: nosniff` — app and nginx static file locations.
+- `X-Frame-Options: DENY` — app and nginx static file locations.
+- `X-XSS-Protection: 1; mode=block`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `X-Permitted-Cross-Domain-Policies: none`
+- `Permissions-Policy` restricting camera, geolocation, microphone, etc.
+- `Content-Security-Policy`: `script-src 'self'` (no unsafe-inline for scripts), PostHog domains whitelisted.
+- CORS: empty origin list by default (same-origin only), explicit whitelist when configured.
+- Nginx adds `X-Content-Type-Options` and `X-Frame-Options` to all static file locations (fixed since 2026-04-26).
+
+#### 9. Data Exposure
+
+- `UserResponse` model excludes `hashed_password` and internal fields.
+- Error messages are generic ("Incorrect email or password") — no user enumeration.
+- API docs (`/docs`, `/redoc`, `/openapi.json`) disabled in production.
+- No stack traces, database names, or file paths in error responses.
+- PostHog public API key properly separated from server-side key.
+- Price tracker endpoint properly gates sensitive fields (GPS, notes, town) to entry owners only.
+- Export endpoints strip `owner_id` from exported data.
+
+#### 10. Git History Review
+
+- Last 30 commits: feature work (admin panel, OAT deploy), bug fixes, version bumps. No security-concerning changes.
+- No secret files accidentally committed (`git log --diff-filter=A` clean).
+- Commit `d9693ca` (2026-04-26) adopted previous security review recommendations.
+- `config/secrets.env.example` is the only secrets-adjacent file in git (contains only placeholders).
+
+#### 11. Infrastructure & Configuration
+
+- Production safety checks at startup: weak secret key blocked, localhost MongoDB warned, HTTPS enforcement checked.
+- Database safety check prevents dev environments from connecting to production MongoDB.
+- Nginx: `server_tokens off`, TLS 1.2/1.3 only, strong ciphers, HSTS 2-year max-age.
+- Admin panel IP-restricted in nginx (`deploy/winebox-admin.toml`).
+- All Anthropic API calls have explicit 60-second timeouts.
+- `invoke deploy` tasks use `shlex.quote()` for shell command parameters.
+- Debug mode and API docs disabled in production.
+
+#### 12. Third-Party Integration Security
+
+- Anthropic API key loaded from environment, never hardcoded.
+- PostHog API key fetched from backend endpoint `/api/config/analytics` — not embedded in client-side code.
+- No webhook endpoints present.
+- All external API calls have timeout configuration.
+
+---
+
+## Comparison with Previous Review (2026-04-26)
+
+| Previous Finding | Status |
+|-----------------|--------|
+| INFO-1: SECURITY.md nonce claim | **Resolved** — nonce references removed |
+| INFO-2: Nginx static file headers | **Resolved** — headers added to all locations |
+| INFO-3: Password strength (length-only) | **Resolved** — UI strength meter with actionable feedback added |
+| INFO-4: Shell command injection in tasks.py | **Resolved** — `shlex.quote()` applied |
+| INFO-5: E2E test secret key hardcoded | **Ongoing** — still present (low risk, see INFO-2 above) |
+
+**New finding this review:** WARN-1 (XSS in static site export) — not present in previous review scope.
+
+---
+
+## 📊 Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 CRITICAL | 0 |
+| 🟠 WARNING | 1 |
+| 🟡 INFO | 3 |
+| 🟢 CLEAN | 12 categories |
+
+**Date of review:** 2026-04-27
+**Reviewer:** Automated security audit (Claude Code)
+**Codebase version:** 0.7.79 (commit 6c7bf94)
+
+### Top 3 Priorities
+
+1. **Fix XSS in static site export** (WARN-1) — apply `html.escape()` to filter values in `static_site_template.py`.
+2. **Cap `list_batches` limit parameter** (INFO-1) — add `Query(default=100, ge=1, le=200)` for consistency.
+3. **Add bounds to reference data queries** (INFO-3) — add `length=` to `to_list()` calls in `reference.py`.

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2796,7 +2796,7 @@ wheels = [
 
 [[package]]
 name = "winebox"
-version = "0.7.77"
+version = "0.7.79"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- 0 CRITICAL, 1 WARNING, 3 INFO findings
- **WARN-1:** XSS in static site export — user-supplied filter values embedded in HTML without `html.escape()` (`static_site_template.py:30-34`)
- INFO-1: `list_batches` limit parameter uncapped
- INFO-2: E2E test secret key still hardcoded (ongoing from previous review)
- INFO-3: Reference data endpoints have unbounded `to_list()` calls
- 4 of 5 findings from the 2026-04-26 review have been resolved

Full report: `docs/security-reports/2026-04-27.md`

https://claude.ai/code/session_01LofLsTwGC3WSg6aGhrLrZD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LofLsTwGC3WSg6aGhrLrZD)_