### PR TITLE
fix: Theme Chart.js text + grid colors so charts flip in dark mode

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2796,7 +2796,7 @@ wheels = [
 
 [[package]]
 name = "winebox"
-version = "0.7.77"
+version = "0.7.79"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/winebox/static/js/app.js
+++ b/winebox/static/js/app.js
@@ -82,9 +82,21 @@ document.addEventListener('DOMContentLoaded', () => {
     initCustomFields();
     initMetPage();
     initAddToCellarPage();
+    initChartTheming();
     checkAuth();
     loadAppInfo();
 });
+
+// Push theme tokens into Chart.js defaults at boot, and re-apply on every
+// theme change so live charts flip with the rest of the UI.
+function initChartTheming() {
+    applyChartTheme();
+    if (window.WineBox && window.WineBox.theme) {
+        window.WineBox.theme.subscribe(() => {
+            requestAnimationFrame(applyChartTheme);
+        });
+    }
+}
 
 // Load app info for footer
 async function loadAppInfo() {
@@ -1878,7 +1890,9 @@ const CHART_DEFAULTS = {
         legend: {
             labels: {
                 font: { family: "'Cormorant Garamond', serif", size: 13 },
-                color: '#444',
+                // color intentionally omitted — inherits Chart.defaults.color,
+                // which applyChartTheme() keeps in sync with --text-color so
+                // legends flip in dark mode.
             },
         },
         tooltip: {
@@ -1887,6 +1901,38 @@ const CHART_DEFAULTS = {
         },
     },
 };
+
+// Push the live theme tokens into Chart.js defaults so axis labels, legends,
+// tooltips, and grid lines flip with the theme. Also patches every live
+// chart in _dashboardCharts because Chart.js bakes defaults at construction
+// time — existing instances need their options updated explicitly.
+function applyChartTheme() {
+    if (typeof Chart === 'undefined') return;
+    const cs = getComputedStyle(document.documentElement);
+    const textColor = cs.getPropertyValue('--text-color').trim() || '#2D1A22';
+    const borderColor = cs.getPropertyValue('--border-color').trim() || '#E8E0D8';
+
+    Chart.defaults.color = textColor;
+    Chart.defaults.borderColor = borderColor;
+
+    Object.values(_dashboardCharts).forEach(chart => {
+        if (!chart || !chart.options) return;
+        chart.options.color = textColor;
+        chart.options.borderColor = borderColor;
+        if (chart.options.plugins?.legend?.labels) {
+            chart.options.plugins.legend.labels.color = textColor;
+        }
+        if (chart.options.scales) {
+            for (const scale of Object.values(chart.options.scales)) {
+                if (scale.ticks) scale.ticks.color = textColor;
+                if (scale.grid && scale.grid.display !== false) {
+                    scale.grid.color = borderColor;
+                }
+            }
+        }
+        chart.update('none');
+    });
+}
 
 function renderDashboardCharts(summary) {
     // Wine Type — doughnut
@@ -1987,7 +2033,7 @@ function _renderHorizontalBarChart(canvasId, data, maxItems) {
                 y: {
                     ticks: {
                         font: { family: "'Cormorant Garamond', serif", size: 12 },
-                        color: '#444',
+                        // color inherits Chart.defaults.color (theme-aware).
                     },
                     grid: { display: false },
                 },


### PR DESCRIPTION
## Summary
- Dashboard donut/bar charts and the History page chart all had hardcoded \`color: '#444'\` on legend labels and y-axis ticks. That doesn't flip in dark mode, so labels rendered nearly invisible against the dark page. Caught in the dark-mode legibility audit (PR C from the original audit report).
- New \`applyChartTheme()\` reads \`--text-color\` / \`--border-color\` from the live \`:root\` and pushes them into \`Chart.defaults\` so axis labels, legends, tooltips, and grid lines inherit theme-aware colors. Also patches every chart in \`_dashboardCharts\` and calls \`update('none')\` because Chart.js bakes defaults at construction time — live instances need their local options updated explicitly.
- \`initChartTheming()\` runs at \`DOMContentLoaded\` and subscribes to \`WineBox.theme\` so dashboards re-render when the user toggles the theme, not just on next page load.

## Test plan
- [x] \`uv run python scripts/lint_static_assets.py\` — clean
- [x] \`uv run python -m pytest tests/ -m \"not e2e\"\` — 815 unit tests pass
- [x] Visual audit: ran \`scripts/audit_dark_mode.py\` against a local server. Before: dashboard chart legends and y-axis labels were nearly invisible in dark mode. After: legend pills, "Top Countries", "Top Grape Varieties", "Vintages" axis ticks all readable in light cream against dark background.

## Notes
This is the last open item from the original dark-mode audit punch list (issues #1–#4 and #5 already shipped via Joe's commits 5e1e948 and bc5b0c6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)