### PR TITLE
Security Review — 2026-05-14 — security-warning

### DIFF
--- a/docs/security-reports/2026-05-14.md
+++ b/docs/security-reports/2026-05-14.md
@@ -1,0 +1,261 @@
+# Security Review — 2026-05-14
+
+## Scope
+
+Comprehensive daily security audit of the WineBox project (FastAPI + MongoDB wine cellar application) covering:
+
+1. Dependency vulnerability check
+2. Hardcoded secrets scan
+3. Authentication & authorization audit
+4. NoSQL injection & query safety
+5. Input validation & injection prevention
+6. Rate limiting & DoS prevention
+7. Session & token security
+8. Security headers & CORS
+9. Data exposure review
+10. Git history review
+11. Infrastructure & configuration
+12. Third-party integration security
+
+---
+
+## Findings
+
+### 🔴 CRITICAL
+
+None.
+
+### 🟠 WARNING
+
+**WARN-1: python-multipart vulnerable to CVE-2026-42561 (header parsing DoS)**
+
+- **File:** `pyproject.toml` (line 31), `uv.lock` (locked at 0.0.26)
+- **CVE:** [CVE-2026-42561](https://cve.threatint.eu/CVE/CVE-2026-42561) — Prior to version 0.0.27, `MultipartParser` imposes no limit on the number of part headers or the size of an individual part header when parsing `multipart/form-data`. An attacker can send requests with many repeated headers or a single very large header, causing excessive CPU consumption.
+- **Impact:** Denial of service via CPU exhaustion on any endpoint that accepts file uploads or multipart form data (scan, import, price tracker photo capture).
+- **Current pin:** `>=0.0.26` — satisfies CVE-2026-40347 (preamble DoS) but not CVE-2026-42561.
+- **Locked version:** 0.0.26
+- **Fix:** Bump the pin to `>=0.0.27` and run `uv lock --upgrade-package python-multipart`.
+
+### 🟡 INFO (Best practice recommendations)
+
+**INFO-1: CVE tracking comments missing for three dependencies** *(carryover from 2026-05-11)*
+
+- **File:** `pyproject.toml`
+- **Detail:** Three dependencies have known CVEs that are already patched by the current version pins, but lack the tracking comments used elsewhere in the file:
+  - `cairosvg>=2.9.0` — CVE-2026-31899 (recursive `<use>` element DoS, CVSS 7.5)
+  - `anthropic>=0.96.0` — CVE-2026-34450 + CVE-2026-34452 (memory tool file permissions and TOCTOU, not used by WineBox)
+  - `python-multipart>=0.0.26` — CVE-2026-40347 (multipart preamble DoS)
+- **Impact:** No security risk — versions are already safe. Documentation consistency issue.
+- **Recommendation:** Add CVE comments matching the existing pattern (e.g. `# CVE-2026-31899 fix`).
+
+**INFO-2: Exception messages exposed in HTTP error details (4 locations)** *(carryover from 2026-05-11)*
+
+- **Files:**
+  - `winebox/routers/import_router.py:180` — `detail=str(e)` for `ValueError`
+  - `winebox/routers/wines/record.py:152` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/met.py:157` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/checkout.py:96` — `detail=str(e)` for `CellarDebitError`
+- **Detail:** All four catch specific exception types (not generic `Exception`), and the messages are user-facing parsing errors or domain-specific errors with controlled messages. No internal paths, database names, or stack traces are leaked.
+- **Impact:** Minimal — these are controlled error messages from known exception types.
+- **Recommendation:** No change required. If future parsing logic grows more complex, consider wrapping with generic user-facing messages.
+
+**INFO-3: E2E test secret keys hardcoded in tasks.py** *(carryover from 2026-05-11)*
+
+- **File:** `tasks.py` (lines 283, 2017)
+- **Values:** `"e2e-test-secret-key-not-for-production-use-1234567890"` and `"oat-e2e-test-secret-key-1234567890"`
+- **Detail:** Clearly labelled test-only values used for isolated E2E test environments. Not used in production. Low risk.
+- **Recommendation:** Consider loading from an environment variable for consistency with project conventions.
+
+**INFO-4: Unbounded `.to_list()` in wine detail transaction history**
+
+- **File:** `winebox/services/cellar_event_view.py:242`
+- **Code:** `events = await CellarEvent.find({...}).sort([("event_date", -1)]).to_list()`
+- **Context:** Used by the wine-detail modal to show full transaction history for a single wine. No `limit` parameter.
+- **Impact:** A wine with thousands of events could cause a memory spike on the server. In practice, wines rarely accumulate more than a few dozen events, so the risk is low.
+- **Recommendation:** Add an explicit limit (e.g. `to_list(length=1000)`) or implement pagination for wine history.
+
+---
+
+### 🟢 CLEAN (Passed review)
+
+#### 1. Dependency Vulnerability Check
+
+All key dependencies are at patched versions (except python-multipart — see WARN-1):
+
+| Package | Locked Version | Status |
+|---------|---------------|--------|
+| fastapi | 0.128.1 | No known 2026 CVEs (latest: 0.136.1) |
+| uvicorn | 0.40.0 | No known 2026 CVEs |
+| pydantic | 2.12.5 | Clean (CVE-2026-25580 affects pydantic-ai only) |
+| pymongo | 4.16.0 | No known 2026 CVEs |
+| pillow | 12.2.0 | Patched for CVE-2026-25990 + CVE-2026-40192 + CVE-2026-42308 |
+| python-multipart | 0.0.26 | **CVE-2026-42561 — needs 0.0.27** (see WARN-1) |
+| jinja2 | 3.1.6 | No known 2026 CVEs |
+| bcrypt | 5.0.0 | No known 2026 CVEs |
+| pyjwt | 2.12.1 | Patched for CVE-2026-32597 |
+| cryptography | 46.0.7 | Patched for CVE-2026-39892 + CVE-2026-34073 |
+| anthropic | 0.96.0 | Patched for CVE-2026-34450 + CVE-2026-34452 |
+| slowapi | 0.1.9 | No known 2026 CVEs |
+| openpyxl | 3.1.5 | No known 2026 CVEs |
+| posthog | 7.13.0 | No known 2026 CVEs |
+| cairosvg | 2.9.0+ | Patched for CVE-2026-31899 |
+| aiohttp | 3.13.5 | Patched for CVE-2026-34520 |
+| requests | 2.33.1 | Patched for CVE-2026-25645 |
+| certifi | 2026.4.22 | Current CA bundle |
+| aioboto3 | 13.0.0+ | No known 2026 CVEs |
+| fastapi-users | 14.0.0+ | No known 2026 CVEs |
+
+No dependencies are yanked, compromised, or more than 2 major versions behind.
+
+#### 2. Hardcoded Secrets Scan
+
+- No API keys, connection strings, passwords, private keys, or JWTs found in source code.
+- `config/secrets.env.example` contains only placeholder values.
+- `.gitignore` properly covers: `.env`, `secrets.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- `git ls-files` confirms no sensitive files tracked (only `config/secrets.env.example`).
+- Test fixtures use obvious dummy values (`sk-ant-api-key`, `phc_test_api_key`, `AKIAIOSFODNN7EXAMPLE`).
+- `mongodb://localhost:27017` default in `config/schema.py` is a safe development default, not a credential.
+
+#### 3. Authentication & Authorization Audit
+
+- **All 60+ endpoints** handling user data require `RequireAuth` or `RequireAdmin`.
+- **All database queries** for user-owned data filter by `owner_id` or `cellar_id`.
+- Public endpoints (`/api/reference/*`, `/api/xwines/*`, `/health`) serve only static reference data — no user information exposed.
+- Admin endpoints use `RequireAdmin` (not just `RequireAuth`).
+- Admin panel login rejects non-admin users with 403.
+- Self-modification prevention: admins cannot deactivate/delete/de-admin their own accounts.
+- Password changes invalidate all existing tokens via dual mechanism:
+  - Per-token blacklist (JTI-based)
+  - Bulk `tokens_invalidated_after` cutoff on user document
+- Constant-time password comparison via Argon2 `verify()` with dummy hash for non-existent users.
+- User registration validates email format (Pydantic `EmailStr`) and password length (8+ chars).
+- Email normalization to lowercase prevents case-sensitivity attacks.
+
+#### 4. NoSQL Injection & Query Safety
+
+- All regex searches use `re.escape()` before compilation (confirmed in `search_service.py`, `reference.py`, `xwines.py`).
+- No unsafe MongoDB operators (`$where`, `$expr`, `$accumulator`, `$function`) found anywhere.
+- All `ObjectId` parsing wrapped in `try/except InvalidId` with proper 400/404 responses.
+- All API inputs validated via Pydantic models — no raw `dict` or untyped JSON bodies.
+- `$in` arrays sourced from internal data (user IDs, wine IDs), never directly from unbounded user input.
+
+#### 5. Input Validation & Injection Prevention
+
+- File uploads validated: magic byte detection, extension whitelist, size limits (configurable, default 10 MB).
+- Path traversal prevented in image serving (`_safe_resolve()` rejects `..`, `/`, `\`; verifies resolved path stays inside storage directory).
+- Generated filenames use UUIDs, not user input.
+- Jinja2 email templates use `autoescape=True`.
+- HTML content generation uses `html.escape()` for user-supplied values.
+- No `eval()`, `exec()`, `__import__()`, or `compile()` in application code.
+- All paginated endpoints enforce maximum limits via `Query(ge=1, le=MAX_PAGE_SIZE)`.
+- Search query length capped at 200 characters.
+
+#### 6. Rate Limiting & DoS Prevention
+
+- **Global:** 60 requests/minute per IP.
+- **Login:** 30/minute, 200/hour + account lockout after 5 failed attempts (15-minute window).
+- **Registration:** 10/minute, 50/hour.
+- **Password reset/change:** 5/minute, 20/hour.
+- **Search:** 120/minute, 2000/hour.
+- **Scan/enrichment:** 20/minute, 200/hour.
+- **X-Wines export:** 10/minute, 30/hour.
+- **Admin login:** 5/minute.
+- All paginated queries bounded by `MAX_USER_RESULTSET` (10,000) and `MAX_REFERENCE_RESULTSET` (5,000).
+- Database query timeouts configured: `serverSelectionTimeoutMS=5000`, `connectTimeoutMS=10000`, `socketTimeoutMS=30000`.
+- Upload size bounded by `max_upload_mb` config (default 10 MB).
+
+#### 7. Session & Token Security
+
+- JWT tokens use HS256 with minimum 32-character secret key (enforced at startup).
+- Tokens include `jti` (UUID), `iat`, `exp`, and `sub` claims.
+- 2-hour token expiry (reduced for security).
+- Dual-layer revocation: per-token JTI blacklist + bulk user `tokens_invalidated_after` cutoff.
+- Background cleanup task purges expired tokens hourly.
+- Revoked token cleanup via MongoDB TTL indexes (automatic).
+- No token values logged anywhere in the codebase.
+- HSTS enabled in production: `max-age=31536000; includeSubDomains; preload`.
+
+#### 8. Security Headers
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `X-XSS-Protection: 1; mode=block`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `X-Permitted-Cross-Domain-Policies: none`
+- `Permissions-Policy` restricting camera, geolocation, microphone, etc.
+- `Content-Security-Policy`: `script-src 'self'` (no `unsafe-inline` for scripts), PostHog domains whitelisted, `frame-ancestors 'none'`, `object-src 'none'`.
+- CORS: empty origin list by default (same-origin only), explicit whitelist when configured.
+- Admin panel reuses the same `SecurityHeadersMiddleware`.
+- API docs (`/docs`, `/redoc`, `/openapi.json`) disabled in production for both main app and admin panel.
+
+#### 9. Data Exposure
+
+- `UserResponse` and `UserRead` models exclude `hashed_password` and internal fields.
+- Error messages are generic ("Invalid email or password") — no user enumeration.
+- Image serving endpoint returns uniform 404 for both "not found" and "not your image" — no ownership leakage.
+- Admin `/info` endpoint intentionally omits MongoDB hostname.
+- Debug mode defaults to `False`; startup validation blocks production launch with debug enabled.
+- No stack traces, database connection strings, or file paths in error responses.
+- PostHog API key loaded from environment, not exposed beyond server-side calls.
+
+#### 10. Git History Review
+
+- Last 30 commits: feature work (backup tasks, admin panel deploy, dashboard fixes), version bumps, security fix adoption. No security-concerning changes.
+- Commit `9d7a297` explicitly adopts the 2026-04-30 audit recommendations.
+- No secret files accidentally committed (`git log --diff-filter=A` clean).
+- `config/secrets.env.example` is the only secrets-adjacent file in git (contains only placeholders).
+- No recent changes to security-critical files (`auth.py`, `settings.py`, `middleware`) beyond the prior security fix adoption.
+
+#### 11. Infrastructure & Configuration
+
+- Production safety checks at startup: weak secret key blocked, localhost MongoDB warned, HTTPS enforcement checked.
+- Database safety check (`_check_database_safety()`) prevents non-production hosts from connecting to production MongoDB.
+- Secure defaults: `debug=False`, `enforce_https=False` (warned in production), `cors_origins=[]` (same-origin), `email_verification_required=True`.
+- Admin panel IP-restricted in nginx with explicit allowlist (no empty sections allowed).
+- API docs disabled in production for both apps.
+- TLS configuration: TLSv1.2 and TLSv1.3 only, strong cipher suites, session tickets disabled.
+- nginx `server_tokens off` hides version.
+- Deployment: secrets.env chmod 600, config.toml chmod 644, proper user ownership.
+- UFW firewall allows only ports 22/80/443.
+- All external API calls have explicit timeouts (30–120 seconds).
+
+#### 12. Third-Party Integration Security
+
+- Anthropic API key loaded from environment variables, not hardcoded. All calls have explicit timeouts (60–120 seconds).
+- PostHog API key loaded from secrets config. Analytics disabled by default (`posthog_enabled=False`).
+- AWS credentials (S3 backup, SES email) loaded from environment via named profile. Never logged.
+- No webhook endpoints that would require signature validation.
+
+---
+
+## 📊 Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 CRITICAL | 0 |
+| 🟠 WARNING | 1 |
+| 🟡 INFO | 4 |
+| 🟢 CLEAN | 12 categories |
+
+**Date of review:** 2026-05-14
+**Reviewer:** Automated security audit (Claude Code)
+**Codebase version:** 0.7.80 (commit bbc839c)
+
+### Comparison with Previous Review (2026-05-11)
+
+| Item | 2026-05-11 | 2026-05-14 | Status |
+|------|-----------|-----------|--------|
+| CRITICAL | 0 | 0 | Maintained |
+| WARNING | 0 | 1 | **New: WARN-1** (CVE-2026-42561) |
+| INFO | 4 | 4 | Maintained |
+| INFO-1 (CVE comments) | Open | Carried forward | No change |
+| INFO-2 (Exception messages) | Open | Carried forward | No change |
+| INFO-3 (E2E test secret keys) | Open | Carried forward | No change |
+| INFO-4 (Password strength) | Open | **Replaced** by new INFO-4 (unbounded to_list) | Changed |
+| WARN-1 (python-multipart) | N/A | **New** | CVE-2026-42561 published since last review |
+
+### Top 3 Priorities
+
+1. **Bump `python-multipart` to `>=0.0.27`** to fix CVE-2026-42561 (WARN-1) — header parsing DoS affecting all multipart endpoints.
+2. Add explicit limit to wine detail history query in `cellar_event_view.py:242` (INFO-4) — defensive measure against memory spikes.
+3. Add CVE tracking comments to `pyproject.toml` for `cairosvg`, `anthropic`, and `python-multipart` (INFO-1) — documentation consistency.


### PR DESCRIPTION
## Summary

- 0 CRITICAL, **1 WARNING**, 4 INFO findings
- **WARN-1:** `python-multipart` locked at 0.0.26 — CVE-2026-42561 (header parsing DoS) requires >= 0.0.27
- INFO items: CVE tracking comments missing (3 deps), exception messages in error details (4 locations), E2E test secret keys in tasks.py, unbounded `.to_list()` in wine detail history

## Action Required

Bump `python-multipart>=0.0.27` in `pyproject.toml` and run `uv lock --upgrade-package python-multipart` to resolve the WARNING.

Full report: `docs/security-reports/2026-05-14.md`

https://claude.ai/code/session_01JdxvThkhkm3M4rCyKGqCjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdxvThkhkm3M4rCyKGqCjR)_