### PR TITLE
Security Review — 2026-05-15 — security-warning

### DIFF
--- a/docs/security-reports/2026-05-15.md
+++ b/docs/security-reports/2026-05-15.md
@@ -1,0 +1,295 @@
+# Security Review — 2026-05-15
+
+## Scope
+
+Comprehensive daily security audit of the WineBox project (FastAPI + MongoDB wine cellar application) covering:
+
+1. Dependency vulnerability check
+2. Hardcoded secrets scan
+3. Authentication & authorization audit
+4. NoSQL injection & query safety
+5. Input validation & injection prevention
+6. Rate limiting & DoS prevention
+7. Session & token security
+8. Security headers & CORS
+9. Data exposure review
+10. Git history review
+11. Infrastructure & configuration
+12. Third-party integration security
+
+**Notable change since last review:** The project migrated its authentication system from an in-house implementation to the embedded `regstack` library (commits `957dee5`–`72482ed`). This review pays special attention to the migration's security surface.
+
+---
+
+## Findings
+
+### 🔴 CRITICAL
+
+None.
+
+### 🟠 WARNING
+
+**WARNING-1: python-multipart CVE-2026-42561 — DoS via unbounded multipart part headers**
+
+- **File:** `pyproject.toml` (pin `>=0.0.26`), `uv.lock` (resolved `0.0.26`)
+- **CVE:** [CVE-2026-42561](https://github.com/advisories/GHSA-pp6c-gr5w-3c5g) — CVSS 7.5 (HIGH)
+- **Detail:** python-multipart prior to 0.0.27 has no limit on the number of multipart part headers or the size of an individual part header. An attacker can send a request with many repeated headers or a single very large header value, causing excessive CPU work. This is directly exploitable against the FastAPI application's multipart/form-data parsing (label upload, import upload, price photo capture).
+- **Impact:** Denial of service — worker or event-loop starvation while processing malicious upload requests. No confidentiality or integrity impact.
+- **Fix:** Bump the minimum to `>=0.0.27` in `pyproject.toml` and run `uv lock --upgrade-package python-multipart`. Latest available is `0.0.28` (released 2026-05-10).
+
+### 🟡 INFO (Best practice recommendations)
+
+**INFO-1: CVE tracking comments missing for three dependencies**
+
+- **File:** `pyproject.toml`
+- **Detail:** Three dependencies have known CVEs already patched by the current version pins, but lack the tracking comments used elsewhere in the file:
+  - `cairosvg>=2.9.0` — CVE-2026-31899 (recursive `<use>` element DoS, CVSS 7.5)
+  - `anthropic>=0.96.0` — CVE-2026-34450 + CVE-2026-34452 (memory tool file permissions and TOCTOU, not used by WineBox)
+  - `python-multipart>=0.0.26` — CVE-2026-40347 (multipart preamble DoS)
+- **Impact:** No security risk — versions are already safe. Documentation consistency issue.
+- **Recommendation:** Add CVE comments matching the existing pattern.
+- **Carried from:** 2026-05-11 review (INFO-1)
+
+**INFO-2: Exception messages exposed in HTTP error details (4 locations)**
+
+- **Files:**
+  - `winebox/routers/import_router.py:180` — `detail=str(e)` for `ValueError`
+  - `winebox/routers/wines/record.py:152` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/met.py:157` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/checkout.py:96` — `detail=str(e)` for `CellarDebitError`
+- **Detail:** All four catch specific exception types with controlled messages. No internal paths, database names, or stack traces are leaked.
+- **Impact:** Minimal — controlled error messages from known exception types.
+- **Carried from:** 2026-05-11 review (INFO-2)
+
+**INFO-3: E2E test secret keys hardcoded in tasks.py**
+
+- **File:** `tasks.py` (lines 283, 2060)
+- **Values:** `"e2e-test-secret-key-not-for-production-use-1234567890"` and `"oat-e2e-test-secret-key-1234567890"`
+- **Detail:** Clearly labelled test-only values used for isolated E2E test environments. Not used in production. Low risk.
+- **Recommendation:** Consider loading from an environment variable for consistency with project conventions.
+- **Carried from:** 2026-05-11 review (INFO-3)
+
+**INFO-4: Password strength validation is length-only (8 characters minimum)**
+
+- **File:** `winebox/auth/schemas.py` (MIN_PASSWORD_LENGTH), regstack's `PasswordStr` field
+- **Detail:** Registration and password change enforce a minimum of 8 characters and a maximum of 128 characters (regstack's schema) but do not require complexity. Acceptable per NIST SP 800-63B guidance which discourages complexity rules.
+- **Recommendation:** Consider optional password strength feedback in the UI.
+- **Carried from:** 2026-05-11 review (INFO-4)
+
+**INFO-5: delete_wine cascade deletes by wine_id without owner_id scope**
+
+- **File:** `winebox/routers/wines/crud.py:188-189`
+- **Detail:** `CellarEvent.find({"wine_id": wine.id}).delete()` and `Transaction.find({"wine_id": wine.id}).delete()` delete by `wine_id` alone without an `owner_id`/`cellar_id` filter. The risk is minimal because the wine is first fetched via `get_wine_or_404(wine_id, current_user.id)` which verifies ownership, and wine IDs are unique ObjectIds belonging to a single owner.
+- **Impact:** Not exploitable in practice due to ObjectId uniqueness. Defense-in-depth improvement.
+- **Recommendation:** Add `"owner_id": current_user.id` or `"cellar_id": current_user.id` to the cascade delete queries.
+
+**INFO-6: Admin delete_user fails to clean up raw upload rows**
+
+- **File:** `winebox/admin/routers/admin.py:317`
+- **Detail:** `await raw_col.delete_many({"owner_id": user.id})` targets a non-existent `owner_id` field on `RawUploadRow` documents. The model uses `batch_id` for association, not `owner_id`. This query silently matches zero documents, leaving orphaned raw upload rows.
+- **Impact:** Data cleanup bug, not a security vulnerability. Orphaned rows contain spreadsheet import data but are inaccessible without knowing the batch_id (which is deleted in the prior step).
+- **Recommendation:** Collect batch_ids for the user first, then delete raw rows by `{"batch_id": {"$in": batch_ids}}`.
+
+**INFO-7: Several Pydantic fields lack max_length constraints**
+
+- **Files:**
+  - `winebox/schemas/wine.py:63,66,69` — `WineUpdate.wine_type`, `price_tier`, `producer_type` have no `max_length`
+  - `winebox/schemas/reference.py:189` — `WineScoreBase.notes` has no `max_length`
+  - `winebox/admin/routers/admin.py:193` — `CreateUserRequest.password` has no `max_length` (Argon2 hashing of very long strings could cause CPU load, mitigated by RequireAdmin + IP allowlist)
+- **Impact:** Low — a user could store arbitrarily long strings, but this is one document per request and bounded by the global upload size limit and rate limiting.
+- **Recommendation:** Add `max_length` constraints (e.g., 200 for wine fields, 128 for passwords, 2000 for notes).
+
+---
+
+### 🟢 CLEAN (Passed review)
+
+#### 1. Dependency Vulnerability Check
+
+All key dependencies are at patched versions (except python-multipart, see WARNING-1):
+
+| Package | Pin | Resolved | Status |
+|---------|-----|----------|--------|
+| fastapi | >=0.109.0 | 0.128.1 | No known 2026 CVEs |
+| uvicorn | >=0.27.0 | 0.40.0 | No known 2026 CVEs |
+| pydantic | >=2.0.0 | 2.12.5 | Clean (CVE-2026-25580 affects pydantic-ai only) |
+| pymongo | >=4.10.0 | 4.16.0 | No known 2026 CVEs |
+| pillow | >=12.2.0 | 12.2.0 | Patched for CVE-2026-25990 + CVE-2026-40192 |
+| python-multipart | >=0.0.26 | 0.0.26 | **VULNERABLE** — CVE-2026-42561 (see WARNING-1) |
+| jinja2 | >=3.1.6 | 3.1.6 | No known 2026 CVEs |
+| bcrypt | >=4.1.2 | 5.0.0 | No known 2026 CVEs |
+| pyjwt | >=2.12.0 | 2.12.1 | Patched for CVE-2026-32597 |
+| cryptography | >=46.0.7 | 46.0.7 | Patched for CVE-2026-39892 + CVE-2026-34073 |
+| anthropic | >=0.96.0 | 0.96.0 | Patched for CVE-2026-34450 + CVE-2026-34452 |
+| slowapi | >=0.1.9 | 0.1.9 | No known 2026 CVEs |
+| openpyxl | >=3.1.0 | 3.1.5 | No known 2026 CVEs |
+| posthog | >=7.0.0 | 7.13.0 | No known 2026 CVEs |
+| cairosvg | >=2.9.0 | 2.9.0 | Patched for CVE-2026-31899 |
+| aiohttp | >=3.13.4 | 3.13.5 | Patched for CVE-2026-34520 |
+| requests | >=2.33.1 | 2.33.1 | Patched for CVE-2026-25645 |
+| certifi | >=2026.4.22 | 2026.4.22 | Current CA bundle |
+| aioboto3 | >=13.0.0 | 15.5.0 | No known 2026 CVEs |
+| regstack | >=0.5.6 | 0.5.6 | No known CVEs |
+
+No dependencies are yanked, compromised, or more than 2 major versions behind.
+
+#### 2. Hardcoded Secrets Scan
+
+- No API keys, connection strings, passwords, private keys, or JWTs found in source code.
+- `config/secrets.env.example` contains only placeholder values.
+- `.gitignore` properly covers: `.env`, `secrets.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- `git ls-files` confirms no sensitive files tracked (only `config/secrets.env.example`).
+- Test fixtures use obvious dummy values (`sk-ant-api-key`, `phc_test_api_key`, `AKIAIOSFODNN7EXAMPLE`).
+- `mongodb://localhost:27017` default in `config/schema.py` is a safe development default, not a credential.
+- No secret files ever committed to git history.
+
+#### 3. Authentication & Authorization Audit
+
+- **All 60+ endpoints** handling user data require `RequireAuth` or `RequireAdmin`.
+- **All database queries** for user-owned data filter by `owner_id` or `cellar_id`.
+- Public endpoints (`/api/reference/*`, `/api/xwines/*`, `/health`) serve only shared reference data — no user information exposed.
+- Admin endpoints use `RequireAdmin` (not just `RequireAuth`).
+- Admin panel login rejects non-admin users with 403.
+- Self-modification prevention: admins cannot deactivate/delete/de-admin their own accounts.
+- **Regstack migration audit:** Password changes and resets properly invalidate all existing tokens via dual mechanism:
+  - Per-token blacklist (JTI-based) via regstack's blacklist service
+  - Bulk `tokens_invalidated_after` cutoff on user document (verified in regstack source: `update_password` bumps cutoff, `current_user()` dependency checks cutoff on every request)
+- CLI `passwd` command also bumps `tokens_invalidated_after` (`winebox/cli/user_admin.py:222`).
+- Constant-time password comparison via Argon2id `verify()` through regstack's `PasswordHasher`.
+- User registration validates email format (Pydantic `EmailStr`) and password length (8–128 chars via regstack schema).
+- Pending registration promotion via admin `verify` command properly creates user via regstack's user repository.
+
+#### 4. NoSQL Injection & Query Safety
+
+- All regex searches use `re.escape()` before compilation (confirmed in `search_service.py`, `reference.py`, `xwines.py`).
+- No unsafe MongoDB operators (`$where`, `$expr`, `$accumulator`, `$function`) found anywhere.
+- All `ObjectId` parsing wrapped in `try/except InvalidId` with proper 400/404 responses.
+- All API inputs validated via Pydantic models — no raw `dict` or untyped JSON bodies.
+- `$in` arrays sourced from internal data (user IDs, wine IDs), never directly from unbounded user input.
+
+#### 5. Input Validation & Injection Prevention
+
+- File uploads validated: magic byte detection, extension whitelist, size limits (configurable, default 10 MB for images, 25 MB for spreadsheets).
+- Path traversal prevented in image serving (`_safe_resolve()` rejects `..`, `/`, `\`; verifies resolved path stays inside storage directory).
+- Generated filenames use UUIDs, not user input.
+- Jinja2 email templates use `autoescape=True`.
+- No `eval()`, `exec()`, `__import__()`, or `compile()` in application code.
+- All paginated endpoints enforce maximum limits via `Query(ge=1, le=MAX_PAGE_SIZE)`.
+- Search query length capped at 200 characters.
+- CSP `script-src 'self'` blocks inline script injection even if XSS were found.
+
+#### 6. Rate Limiting & DoS Prevention
+
+- **Global:** 60 requests/minute per IP.
+- **Login:** 30/minute, 200/hour + account lockout after 5 failed attempts (15-minute window).
+- **Registration:** 10/minute, 50/hour.
+- **Password reset/change:** 5/minute, 20/hour.
+- **Search:** 120/minute, 2000/hour.
+- **Scan/enrichment:** 20/minute, 200/hour.
+- **X-Wines export:** 10/minute, 30/hour.
+- **Admin login:** 5/minute.
+- All paginated queries bounded by `MAX_USER_RESULTSET` (10,000) and `MAX_REFERENCE_RESULTSET` (5,000).
+- Database query timeouts configured: `serverSelectionTimeoutMS=5000`, `connectTimeoutMS=10000`, `socketTimeoutMS=30000`.
+- Upload size bounded by `max_upload_mb` config (default 10 MB).
+- OAT rate limits intentionally disabled (IP-restricted internal environment, per-account lockout still active).
+
+#### 7. Session & Token Security
+
+- JWT tokens signed via regstack with per-purpose key derivation from `WINEBOX_REGSTACK_JWT_SECRET`.
+- Tokens include `jti` (UUID), `iat`, `exp`, and `sub` claims.
+- 2-hour token expiry.
+- Dual-layer revocation: per-token JTI blacklist + bulk user `tokens_invalidated_after` cutoff.
+- Minimum 32-character secret key enforced at startup (blocks production launch with weak key).
+- Separate regstack JWT secret with dev fallback warning.
+- No token values logged anywhere in the codebase.
+- HSTS enabled in production: `max-age=31536000; includeSubDomains; preload`.
+
+#### 8. Security Headers
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `X-XSS-Protection: 1; mode=block`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `X-Permitted-Cross-Domain-Policies: none`
+- `Permissions-Policy` restricting camera, geolocation, microphone, etc.
+- `Content-Security-Policy`: `script-src 'self'` (no `unsafe-inline` for scripts), PostHog domains whitelisted, `frame-ancestors 'none'`, `object-src 'none'`.
+- CORS: empty origin list by default (same-origin only), explicit whitelist when configured.
+- Admin panel reuses the same `SecurityHeadersMiddleware`.
+- API docs (`/docs`, `/redoc`, `/openapi.json`) disabled in production for both main app and admin panel.
+
+#### 9. Data Exposure
+
+- `UserResponse` and user info endpoints exclude `hashed_password` and internal fields.
+- Error messages are generic ("Invalid email or password") — no user enumeration.
+- Image serving endpoint returns uniform 404 for both "not found" and "not your image" — no ownership leakage.
+- Admin `/info` endpoint intentionally omits MongoDB hostname.
+- Debug mode defaults to `False`; startup validation blocks production launch with debug enabled.
+- No stack traces, database connection strings, or file paths in error responses.
+- PostHog API key loaded from environment, not exposed beyond server-side calls.
+- Export endpoints strip `owner_id` from output.
+- Price tracker redacts other users' PII (GPS, notes, photos) from crowdsourced entries.
+
+#### 10. Git History Review
+
+- Last 30 commits: regstack migration, E2E CI improvements, version bumps. No security-concerning changes.
+- Regstack migration (`957dee5`) replaces in-house auth with a well-tested library — net security improvement.
+- Rate limit wiring (`926f663`) applies per-route limits via regstack 0.5.6.
+- Admin verify fix (`72482ed`) correctly promotes pending registrations.
+- No secret files accidentally committed (`git log --diff-filter=A` clean).
+- `config/secrets.env.example` is the only secrets-adjacent file in git (contains only placeholders).
+
+#### 11. Infrastructure & Configuration
+
+- Production safety checks at startup: weak secret key blocked, localhost MongoDB warned, HTTPS enforcement checked.
+- Database safety check (`_check_database_safety()`) prevents non-production hosts from connecting to production MongoDB via FQDN validation.
+- Secure defaults: `debug=False`, `enforce_https=False` (warned in production), `cors_origins=[]` (same-origin), `email_verification_required=True`.
+- Admin panel IP-restricted in nginx with explicit allowlist (empty sections rejected by renderer).
+- API docs disabled in production for both apps.
+- Systemd hardening: `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`.
+- nginx: TLS 1.2+, strong ciphers, `server_tokens off`, HSTS.
+- Deploy secrets sync includes `WINEBOX_REGSTACK_JWT_SECRET` (`deploy/common.py:414`).
+
+#### 12. Third-Party Integration Security
+
+- Anthropic API key loaded from environment variables, not hardcoded. All calls have explicit timeouts (60–120 seconds).
+- PostHog API key loaded from secrets config. Analytics disabled by default (`posthog_enabled=False`).
+- AWS credentials (S3 backup, SES email) loaded from environment via named profile. Never logged.
+- DigitalOcean API calls have 30-second timeouts.
+- No webhook endpoints that would require signature validation.
+
+---
+
+## 📊 Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 CRITICAL | 0 |
+| 🟠 WARNING | 1 |
+| 🟡 INFO | 7 |
+| 🟢 CLEAN | 12 categories |
+
+**Date of review:** 2026-05-15
+**Reviewer:** Automated security audit (Claude Code)
+**Codebase version:** 0.7.82 (commit 47904ca)
+
+### Comparison with Previous Review (2026-05-11)
+
+| Item | 2026-05-11 | 2026-05-15 | Status |
+|------|-----------|-----------|--------|
+| CRITICAL | 0 | 0 | Maintained |
+| WARNING | 0 | 1 | **New** — CVE-2026-42561 (python-multipart DoS) |
+| INFO | 4 | 7 | 4 carried forward, 3 new |
+| INFO-1 (CVE tracking comments) | Open | Carried forward | No change |
+| INFO-2 (exception messages) | Open | Carried forward | No change |
+| INFO-3 (E2E test secret keys) | Open | Carried forward | No change |
+| INFO-4 (password strength) | Open | Carried forward | No change |
+| INFO-5 (delete_wine cascade scope) | N/A | New | Defense-in-depth |
+| INFO-6 (admin delete_user cleanup) | N/A | New | Data cleanup bug |
+| INFO-7 (max_length constraints) | N/A | New | Input validation hardening |
+
+### Top 3 Priorities
+
+1. **Bump python-multipart to >=0.0.27** to fix CVE-2026-42561 (WARNING-1) — network-exploitable DoS against multipart form parsing.
+2. Add `owner_id`/`cellar_id` scoping to cascade delete queries in `delete_wine` (INFO-5) — defense-in-depth.
+3. Fix admin `delete_user` raw upload cleanup to use `batch_id` instead of non-existent `owner_id` (INFO-6) — data hygiene.
+
+**Overall assessment:** The regstack migration is well-executed with proper auth delegation, token revocation, and rate limiting. One new WARNING-level dependency vulnerability (CVE-2026-42561) requires a version bump. The codebase maintains strong security practices across all audit categories.


### PR DESCRIPTION
## Summary

Daily security audit of the WineBox codebase (v0.7.82). Special attention paid to the regstack auth migration that landed since the last review.

- **0 CRITICAL** findings
- **1 WARNING** finding: python-multipart CVE-2026-42561 (DoS via unbounded multipart part headers, CVSS 7.5) — locked at 0.0.26, fix is in 0.0.27+
- **7 INFO** findings (4 carried forward from 2026-05-11, 3 new)
- **12 categories** reviewed and passed

### WARNING-1: python-multipart CVE-2026-42561

The project's `uv.lock` resolves python-multipart to 0.0.26, which is vulnerable to [CVE-2026-42561](https://github.com/advisories/GHSA-pp6c-gr5w-3c5g) — a denial of service via unbounded multipart part headers. Fix: bump `pyproject.toml` pin to `>=0.0.27` and run `uv lock --upgrade-package python-multipart`.

### New INFO items

- **INFO-5**: `delete_wine` cascade deletes CellarEvents/Transactions by `wine_id` without `owner_id` scope (defense-in-depth)
- **INFO-6**: Admin `delete_user` fails to clean up `RawUploadRow` documents (queries non-existent `owner_id` field)
- **INFO-7**: Several Pydantic model fields lack `max_length` constraints

Full report: `docs/security-reports/2026-05-15.md`

https://claude.ai/code/session_01JFUZi281Gn4KvjpTbN1uqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFUZi281Gn4KvjpTbN1uqk)_