### PR TITLE
fix(security): derive price-tracker photo extension from magic bytes

### DIFF
--- a/tests/test_price_tracker.py
+++ b/tests/test_price_tracker.py
@@ -209,6 +209,26 @@ async def test_invalid_photo_content_type_rejected(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_photo_extension_derived_from_magic_bytes_not_filename(
+    client: AsyncClient, sample_image_bytes: bytes
+) -> None:
+    """A JPEG body uploaded under ``filename='evil.html'`` must land on
+    disk with ``.jpg``, not ``.html`` — otherwise Starlette serves it
+    as text/html and the photo is a stored-XSS vector. Regression for
+    the 2026-05-17 security review WARNING-1.
+    """
+    name = f"Spoofed {uuid.uuid4().hex[:6]}"
+    spoofed = ("evil.html", io.BytesIO(sample_image_bytes), "image/png")
+    body = await _create_price(client, wine_name=name, photo=spoofed)
+    photo_url = body["prices"][0]["photo_url"]
+    assert photo_url is not None
+    assert photo_url.endswith(".png"), (
+        f"Photo URL should end with the magic-byte-derived extension "
+        f"(.png for the test PNG body), not the spoofed .html. Got: {photo_url}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_photo_too_large_rejected(client: AsyncClient) -> None:
     big_photo = ("huge.png", io.BytesIO(b"\x00" * (10 * 1024 * 1024 + 1)), "image/png")
     response = await client.post(

--- a/winebox/routers/price_tracker.py
+++ b/winebox/routers/price_tracker.py
@@ -49,6 +49,43 @@ limiter = make_limiter()
 PRICE_PHOTOS_DIR = "price_captures"
 
 
+# Magic-byte signatures for the formats the mobile capture flow accepts.
+# Mirrors `winebox.services.image_storage.detect_image_type` for JPEG /
+# PNG / WebP but ALSO includes HEIC (iPhone default), which the wine-
+# label flow doesn't accept. Inline rather than shared so widening the
+# capture allow-list never accidentally widens the label allow-list.
+_CAPTURE_MAGIC_SIGNATURES: tuple[tuple[bytes, int, str], ...] = (
+    (b"\xff\xd8\xff", 0, "jpg"),
+    (b"\x89PNG\r\n\x1a\n", 0, "png"),
+    (b"RIFF", 0, "webp"),   # WEBP additionally verified at offset 8
+    (b"ftyp", 4, "heic"),    # HEIC brand additionally verified at offset 8
+)
+# Brand identifiers (at offset 8) that mean an ISO BMFF `ftyp` box is
+# carrying HEIC payload. Without this check, an MP4 or QuickTime video
+# would slip past because it shares the same `ftyp` header.
+_HEIC_BRANDS = frozenset({
+    b"heic", b"heix", b"hevc", b"hevx", b"heim", b"heis", b"hevm",
+    b"hevs", b"mif1",
+})
+
+
+def _detect_capture_image_type(content: bytes) -> str | None:
+    """Return the extension (no leading dot) for a recognised capture
+    photo, or ``None`` if the content doesn't match an allowed format.
+    """
+    if len(content) < 12:
+        return None
+    for magic, offset, ext in _CAPTURE_MAGIC_SIGNATURES:
+        if content[offset:offset + len(magic)] != magic:
+            continue
+        if ext == "webp" and content[8:12] != b"WEBP":
+            continue
+        if ext == "heic" and content[8:12] not in _HEIC_BRANDS:
+            continue
+        return ext
+    return None
+
+
 def _photo_storage_path() -> Path:
     """Get the directory for storing price capture photos."""
     path = settings.image_storage_path / PRICE_PHOTOS_DIR
@@ -203,7 +240,18 @@ async def create_price_capture(
         if len(content) > MAX_PHOTO_BYTES:
             raise HTTPException(status_code=422, detail="Photo too large (max 10 MB).")
 
-        ext = photo.filename.rsplit(".", 1)[-1].lower() if "." in photo.filename else "jpg"
+        # Derive the on-disk extension from the file's actual magic bytes,
+        # NOT from `photo.filename`. A client supplying
+        # ``filename="evil.html"`` with a valid JPEG body would otherwise
+        # land a `.html`-suffixed file in storage that Starlette later
+        # serves with `Content-Type: text/html`, which is a stored-XSS
+        # vector even with `X-Content-Type-Options: nosniff` set elsewhere.
+        ext = _detect_capture_image_type(content)
+        if ext is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Photo must be JPEG, PNG, WebP, or HEIC.",
+            )
         filename = f"{uuid.uuid4().hex}.{ext}"
         dest = _photo_storage_path() / filename
         dest.write_bytes(content)


### PR DESCRIPTION
## Summary

Closes #68 (security review 2026-05-17 WARNING-1).

`winebox/routers/price_tracker.py` was extracting the on-disk filename extension from `photo.filename`, the client-supplied multipart-form field. A request supplying `filename="evil.html"` with a valid JPEG body would have landed a `.html`-suffixed file in `/opt/winebox/data/images/price_captures/`. When Starlette later served the file back through `/api/prices/photos/<name>`, it would infer `Content-Type: text/html` from the extension — turning the upload into a stored-XSS vector even with the `X-Content-Type-Options: nosniff` header set globally.

## Fix

Read content first, run a magic-byte check that recognises JPEG / PNG / WebP / HEIC, and use the detected extension for the on-disk filename. Reject the upload (422) when content doesn't match any allowed format.

The magic-byte logic lives inline in `price_tracker.py` rather than in `winebox.services.image_storage.detect_image_type` because the mobile capture flow accepts HEIC (iPhone default) while the wine-label flow deliberately doesn't — sharing one detector would widen the label-storage allow-list as a side effect. HEIC detection verifies both `ftyp` at offset 4 AND an ISO/IEC 23008-12 HEIC brand identifier at offset 8 (`mif1`/`heic`/`heix`/`hevc`/`hevx`/`heim`/`heis`/`hevm`/`hevs`), so MP4/QuickTime videos (which share the `ftyp` header) don't slip past.

## Test plan

- [x] New `test_photo_extension_derived_from_magic_bytes_not_filename` regression — upload JPEG content under `filename="evil.html"`, assert returned `photo_url` ends in `.png` (the magic-byte verdict for the test fixture).
- [x] Full price-tracker suite passes (39/39).
- [x] Full non-E2E suite passes (752/752, up by 1 from the new test).
- [ ] OAT E2E will run against this on next nightly.