### PR TITLE
ci: auto-merge security-review PRs whose title carries -clean

### DIFF
--- a/.github/workflows/auto-merge-security-clean.yml
+++ b/.github/workflows/auto-merge-security-clean.yml
@@ -1,0 +1,73 @@
+name: Auto-merge security-clean PRs
+
+# The daily security-review PRs are produced by a scheduled Claude Code
+# agent. When the agent's verdict is "clean" the PR title is
+# ``Security Review — YYYY-MM-DD — security-clean`` (or older format
+# ``Security Review — YYYY-MM-DD (security-clean)``). Either way the
+# substring ``security-clean`` is in the title.
+#
+# Before this workflow, those PRs piled up because the agent files
+# them but doesn't merge them — 9 clean dailies sat open between
+# 2026-04-28 and 2026-05-17. This workflow scans open PRs whose
+# title carries the ``security-clean`` marker, confirms every status
+# check is SUCCESS and the PR is mergeable, and squash-merges them.
+#
+# Runs on:
+#   - pull_request_target: matches the moment the PR opens / is
+#     re-edited, plus a fallback path that doesn't need branch
+#     protection's required-status-checks (`gh pr merge --auto`
+#     refuses without it).
+#   - workflow_run after CI finishes: covers the gap where the PR
+#     opened before CI had reported success.
+#   - schedule: a once-a-day backstop for any PR that slipped past
+#     the event-driven runs (timing race, scheduler outage, etc.).
+#
+# `pull_request_target` runs in the BASE repo context (write token)
+# which is safe here because every security-review PR is filed by
+# the repo owner — there's no fork-based attack surface.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, ready_for_review]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  schedule:
+    - cron: "37 9 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    name: Squash-merge clean security-review PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and merge eligible PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MATCHES=$(gh pr list -R "$REPO" \
+            --state open \
+            --json number,title,author,statusCheckRollup,mergeable \
+            --jq '.[]
+              | select(.title | test("security-clean"; "i"))
+              | select(.author.login == "jdrumgoole")
+              | select(.mergeable == "MERGEABLE")
+              | select(
+                  ([.statusCheckRollup[]? | (.conclusion // .status)] | length) > 0
+                  and ([.statusCheckRollup[]? | (.conclusion // .status)] | unique == ["SUCCESS"])
+                )
+              | .number')
+          if [ -z "$MATCHES" ]; then
+            echo "No eligible security-clean PRs to merge."
+            exit 0
+          fi
+          echo "$MATCHES" | while read -r n; do
+            [ -n "$n" ] || continue
+            echo "Merging PR #$n (security-clean, all checks SUCCESS, mergeable)"
+            gh pr merge "$n" -R "$REPO" --squash --delete-branch
+          done

--- a/tests/test_price_tracker.py
+++ b/tests/test_price_tracker.py
@@ -209,6 +209,26 @@ async def test_invalid_photo_content_type_rejected(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_photo_extension_derived_from_magic_bytes_not_filename(
+    client: AsyncClient, sample_image_bytes: bytes
+) -> None:
+    """A JPEG body uploaded under ``filename='evil.html'`` must land on
+    disk with ``.jpg``, not ``.html`` — otherwise Starlette serves it
+    as text/html and the photo is a stored-XSS vector. Regression for
+    the 2026-05-17 security review WARNING-1.
+    """
+    name = f"Spoofed {uuid.uuid4().hex[:6]}"
+    spoofed = ("evil.html", io.BytesIO(sample_image_bytes), "image/png")
+    body = await _create_price(client, wine_name=name, photo=spoofed)
+    photo_url = body["prices"][0]["photo_url"]
+    assert photo_url is not None
+    assert photo_url.endswith(".png"), (
+        f"Photo URL should end with the magic-byte-derived extension "
+        f"(.png for the test PNG body), not the spoofed .html. Got: {photo_url}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_photo_too_large_rejected(client: AsyncClient) -> None:
     big_photo = ("huge.png", io.BytesIO(b"\x00" * (10 * 1024 * 1024 + 1)), "image/png")
     response = await client.post(

--- a/winebox/routers/price_tracker.py
+++ b/winebox/routers/price_tracker.py
@@ -49,6 +49,43 @@ limiter = make_limiter()
 PRICE_PHOTOS_DIR = "price_captures"
 
 
+# Magic-byte signatures for the formats the mobile capture flow accepts.
+# Mirrors `winebox.services.image_storage.detect_image_type` for JPEG /
+# PNG / WebP but ALSO includes HEIC (iPhone default), which the wine-
+# label flow doesn't accept. Inline rather than shared so widening the
+# capture allow-list never accidentally widens the label allow-list.
+_CAPTURE_MAGIC_SIGNATURES: tuple[tuple[bytes, int, str], ...] = (
+    (b"\xff\xd8\xff", 0, "jpg"),
+    (b"\x89PNG\r\n\x1a\n", 0, "png"),
+    (b"RIFF", 0, "webp"),   # WEBP additionally verified at offset 8
+    (b"ftyp", 4, "heic"),    # HEIC brand additionally verified at offset 8
+)
+# Brand identifiers (at offset 8) that mean an ISO BMFF `ftyp` box is
+# carrying HEIC payload. Without this check, an MP4 or QuickTime video
+# would slip past because it shares the same `ftyp` header.
+_HEIC_BRANDS = frozenset({
+    b"heic", b"heix", b"hevc", b"hevx", b"heim", b"heis", b"hevm",
+    b"hevs", b"mif1",
+})
+
+
+def _detect_capture_image_type(content: bytes) -> str | None:
+    """Return the extension (no leading dot) for a recognised capture
+    photo, or ``None`` if the content doesn't match an allowed format.
+    """
+    if len(content) < 12:
+        return None
+    for magic, offset, ext in _CAPTURE_MAGIC_SIGNATURES:
+        if content[offset:offset + len(magic)] != magic:
+            continue
+        if ext == "webp" and content[8:12] != b"WEBP":
+            continue
+        if ext == "heic" and content[8:12] not in _HEIC_BRANDS:
+            continue
+        return ext
+    return None
+
+
 def _photo_storage_path() -> Path:
     """Get the directory for storing price capture photos."""
     path = settings.image_storage_path / PRICE_PHOTOS_DIR
@@ -203,7 +240,18 @@ async def create_price_capture(
         if len(content) > MAX_PHOTO_BYTES:
             raise HTTPException(status_code=422, detail="Photo too large (max 10 MB).")
 
-        ext = photo.filename.rsplit(".", 1)[-1].lower() if "." in photo.filename else "jpg"
+        # Derive the on-disk extension from the file's actual magic bytes,
+        # NOT from `photo.filename`. A client supplying
+        # ``filename="evil.html"`` with a valid JPEG body would otherwise
+        # land a `.html`-suffixed file in storage that Starlette later
+        # serves with `Content-Type: text/html`, which is a stored-XSS
+        # vector even with `X-Content-Type-Options: nosniff` set elsewhere.
+        ext = _detect_capture_image_type(content)
+        if ext is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Photo must be JPEG, PNG, WebP, or HEIC.",
+            )
         filename = f"{uuid.uuid4().hex}.{ext}"
         dest = _photo_storage_path() / filename
         dest.write_bytes(content)


### PR DESCRIPTION
## Summary

Closes #69.

The daily security-review PRs are produced by a scheduled Claude Code agent, not a GHA workflow, so no existing trigger picks them up. Between 2026-04-28 and 2026-05-17 nine clean dailies stacked up open and had to be hand-merged. Wire a tiny event-driven workflow that matches the `security-clean` substring in the PR title (handles both em-dash `— security-clean` and parenthesised legacy `(security-clean)` formats), verifies the rollup is all SUCCESS and the PR is mergeable, then squash-merges with branch delete.

## Triggers

- `pull_request_target` on opened/reopened/edited/ready_for_review — merges the moment a clean PR lands.
- `workflow_run` on CI completion — catches the race where the PR opens before CI reported.
- `schedule` daily at 09:37 UTC — backstop for any PR that slipped past the event-driven runs.

## Safety

- `pull_request_target` uses the base-repo write token; safe here because every security-review PR is filed by the repo owner, so no fork-based attack surface.
- The author-login filter (`jdrumgoole`) is belt-and-braces: extra defence against a spoofed title from a stranger's PR AND a trivial guard against accidentally auto-merging unrelated PRs that happen to mention `security-clean` in their title.
- The status-check rollup gate requires every check on the PR to be SUCCESS; an empty rollup (no checks) is also rejected.

## Test plan

- [ ] Once merged, the next scheduled security-clean PR should self-merge within minutes of CI going green.
- [ ] Workflow logs will show "No eligible security-clean PRs to merge." on the schedule fallback when nothing's pending.