### PR TITLE
Security Review — 2026-05-19 — security-clean

### DIFF
--- a/docs/security-reports/2026-05-19.md
+++ b/docs/security-reports/2026-05-19.md
@@ -1,0 +1,286 @@
+# Security Review — 2026-05-19
+
+## Scope
+
+Comprehensive daily security audit of the WineBox project (FastAPI + MongoDB wine cellar application) covering:
+
+1. Dependency vulnerability check
+2. Hardcoded secrets scan
+3. Authentication & authorization audit
+4. NoSQL injection & query safety
+5. Input validation & injection prevention
+6. Rate limiting & DoS prevention
+7. Session & token security
+8. Security headers & CORS
+9. Data exposure review
+10. Git history review
+11. Infrastructure & configuration
+12. Third-party integration security
+
+**Notable context:** No code changes since the last review (2026-05-18). HEAD is still at commit `6f325c7` (the 2026-05-18 security review merge). All findings are carried forward or newly verified against current dependency databases.
+
+---
+
+## Findings
+
+### :red_circle: CRITICAL
+
+None.
+
+### :orange_circle: WARNING
+
+None.
+
+### :yellow_circle: INFO (Best practice recommendations)
+
+**INFO-1: CVE tracking comments missing for three dependencies**
+
+- **File:** `pyproject.toml`
+- **Detail:** Three dependencies have known CVEs that are already patched by the current version pins, but lack the tracking comments used elsewhere in the file:
+  - `cairosvg>=2.9.0` — CVE-2026-31899 (recursive `<use>` element DoS, CVSS 7.5)
+  - `anthropic>=0.96.0` — CVE-2026-34450 + CVE-2026-34452 (memory tool file permissions and TOCTOU, not used by WineBox)
+  - `python-multipart>=0.0.26` — CVE-2026-40347 (multipart preamble DoS)
+- **Impact:** No security risk — versions are already safe. Documentation consistency issue.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-2: Exception messages exposed in HTTP error details (4 locations)**
+
+- **Files:**
+  - `winebox/routers/import_router.py:180` — `detail=str(e)` for `ValueError`
+  - `winebox/routers/wines/record.py:152` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/met.py:157` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/checkout.py:96` — `detail=str(e)` for `CellarDebitError`
+- **Detail:** All four catch specific exception types (not generic `Exception`), and the messages are user-facing parsing errors or domain-specific errors with controlled messages. No internal paths, database names, or stack traces are leaked.
+- **Impact:** Minimal — these are controlled error messages from known exception types.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-3: E2E test secret keys hardcoded in tasks.py**
+
+- **File:** `tasks.py` (lines 283, 2060)
+- **Values:** `"e2e-test-secret-key-not-for-production-use-1234567890"` and `"oat-e2e-test-secret-key-1234567890"`
+- **Detail:** Clearly labelled test-only values used for isolated E2E test environments. Not used in production. Low risk.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-4: Password strength validation is length-only (8 characters minimum)**
+
+- **File:** regstack's `PasswordStr` type (min_length=8, max_length=128)
+- **Detail:** Registration and password change enforce a minimum of 8 characters but do not require complexity. This is acceptable per NIST SP 800-63B guidance (which discourages complexity rules).
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-5: `cairosvg` dependency appears unused**
+
+- **File:** `pyproject.toml` line 48
+- **Detail:** `cairosvg>=2.9.0` is declared as a dependency but is not imported anywhere in the codebase (`winebox/`, `scripts/`, `tests/`). Keeping an unused dependency increases attack surface without benefit.
+- **Recommendation:** Confirm whether CairoSVG is needed for a planned feature; if not, remove it from dependencies.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-6: nginx `client_max_body_size` is lower than the import upload app-level limit**
+
+- **Files:** `deploy/nginx-winebox.conf:191` (`client_max_body_size 10M`), `winebox/routers/import_router.py:143` (`MAX_IMPORT_BYTES = 25 MB`)
+- **Detail:** The application claims to accept spreadsheet imports up to 25 MB, but nginx rejects requests above 10 MB. Uploads between 10-25 MB will fail with a nginx 413 error before reaching the application.
+- **Impact:** No security risk — this is a functionality gap, not a vulnerability. The lower nginx limit is actually more conservative.
+- **Recommendation:** Either raise `client_max_body_size` to 25M or lower the application limit to match 10M.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-7: `cryptography` package is 2 major versions behind latest**
+
+- **File:** `uv.lock` — pinned at 46.0.7, latest is 48.0.0 (released 2026-05-04)
+- **Detail:** All known CVEs (CVE-2026-39892, CVE-2026-34073, CVE-2026-26007) are patched at 46.0.7. The version gap itself is not a vulnerability, but staying current is advisable for defence in depth.
+- **Recommendation:** Plan upgrade to 48.x in a future maintenance cycle.
+- **Status:** Carried forward from 2026-05-17 review.
+
+---
+
+### :green_circle: CLEAN (Passed review)
+
+#### 1. Dependency Vulnerability Check
+
+All key dependencies are at patched versions:
+
+| Package | Pin | Locked | Status |
+|---------|-----|--------|--------|
+| fastapi | >=0.109.0 | 0.128.1 | No direct 2026 CVEs (CVE-2026-2978/2979 affect fastapi-admin, not fastapi) |
+| uvicorn | >=0.27.0 | 0.40.0 | No known 2026 CVEs |
+| pydantic | >=2.0.0 | 2.12.5 | Clean (CVE-2026-25580 affects pydantic-ai, not pydantic core) |
+| pymongo | >=4.10.0 | 4.16.0 | No known 2026 CVEs |
+| pillow | >=12.2.0 | 12.2.0 | Patched for CVE-2026-25990 + CVE-2026-40192 + CVE-2026-42308 |
+| python-multipart | >=0.0.26 | 0.0.28 | Patched for CVE-2026-40347 + CVE-2026-24486 |
+| jinja2 | >=3.1.6 | 3.1.6 | No known 2026 CVEs |
+| bcrypt | >=4.1.2 | 5.0.0 | Clean |
+| pyjwt | >=2.12.0 | 2.12.1 | Patched for CVE-2026-32597 |
+| cryptography | >=46.0.7 | 46.0.7 | Patched for CVE-2026-39892 + CVE-2026-34073 (see INFO-7 re version gap) |
+| anthropic | >=0.96.0 | 0.96.0 | Patched for CVE-2026-34450 + CVE-2026-34452 |
+| slowapi | >=0.1.9 | 0.1.9 | No known 2026 CVEs |
+| openpyxl | >=3.1.0 | 3.1.5 | No known 2026 CVEs |
+| posthog | >=7.0.0 | 7.13.0 | No known 2026 CVEs |
+| cairosvg | >=2.9.0 | 2.9.0 | Patched for CVE-2026-31899 (see INFO-5 re unused) |
+| aiohttp | >=3.13.4 | 3.13.5 | Patched for CVE-2026-34520 + CVE-2026-34519 + CVE-2026-34516 |
+| requests | >=2.33.1 | 2.33.1 | Patched for CVE-2026-25645 |
+| certifi | >=2026.4.22 | 2026.4.22 | Current CA bundle |
+| regstack | >=0.7.0 | 0.7.0 | No known CVEs |
+| httpx | — | 0.28.1 | No known 2026 CVEs |
+| fastapi-users | >=14.0.0 | 15.0.4 | No known 2026 CVEs |
+
+No dependencies are yanked, compromised, or missing critical patches. No lockfile changes since last review.
+
+#### 2. Hardcoded Secrets Scan
+
+- No API keys, connection strings, passwords, private keys, or JWTs found in source code.
+- `.gitignore` properly covers: `.env`, `secrets.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- `git ls-files` confirms no sensitive files tracked (only `config/secrets.env.example`).
+- Test fixtures use obvious dummy values (`sk-ant-api-key`, `phc_test_api_key`, `AKIAIOSFODNN7EXAMPLE`).
+- `mongodb://localhost:27017` default in `config/schema.py` is a safe development default.
+- No secrets found in git history via `git log --diff-filter=A`.
+
+#### 3. Authentication & Authorization Audit
+
+All 97 endpoints across 25 router files audited:
+
+- **All database queries** for user-owned data filter by `owner_id` or `cellar_id`.
+- Public endpoints (`/api/reference/*`, `/api/xwines/*`, `/health`, `/api/config/analytics`) serve only static reference data — no user information exposed.
+- Admin endpoints use `RequireAdmin` (not just `RequireAuth`).
+- Admin panel login rejects non-admin users with 403.
+- Self-modification prevention: admins cannot deactivate/delete/de-admin their own accounts.
+- Password changes invalidate all existing tokens via dual mechanism:
+  - Per-token blacklist (JTI-based)
+  - Bulk `tokens_invalidated_after` cutoff on user document
+- Constant-time password comparison via Argon2id `verify()` (pwdlib).
+- User registration validates email format (Pydantic `EmailStr`) and password length (8-128 chars).
+- JWT tokens use purpose-separated derived keys (session, password_reset, email_change) via HMAC-SHA256.
+- Anti-enumeration: forgot-password always returns the same message regardless of email existence.
+
+#### 4. NoSQL Injection & Query Safety
+
+- All regex searches use `re.escape()` before compilation (confirmed in `search_service.py`, `reference.py`, `xwines.py`, `xwines_enrichment.py`).
+- No unsafe MongoDB operators (`$where`, `$expr`, `$accumulator`, `$function`) found anywhere.
+- All `ObjectId` parsing wrapped in `try/except InvalidId` with proper 400/404 responses.
+- All API inputs validated via Pydantic models — no raw `dict` or untyped JSON bodies.
+- `$in` arrays sourced from internal data (user IDs, wine IDs), never directly from unbounded user input.
+
+#### 5. Input Validation & Injection Prevention
+
+- File uploads validated: magic byte detection (main image storage + price captures), extension whitelist, size limits.
+- Path traversal prevented in image serving (`_safe_resolve()` rejects `..`, `/`, `\`; verifies resolved path stays inside storage directory).
+- Generated filenames use UUIDs, not user input.
+- Jinja2 email templates use `autoescape=True`.
+- No `eval()`, `exec()`, `__import__()`, or `compile()` in application code.
+- All paginated endpoints enforce maximum limits via `Query(ge=1, le=MAX_PAGE_SIZE)`.
+- Search query length capped at 200 characters.
+- Static site export uses `html.escape()` and custom `escapeHtml()` JS function.
+
+#### 6. Rate Limiting & DoS Prevention
+
+- **Global:** 60 requests/minute per IP.
+- **Login:** 30/minute, 200/hour + account lockout after 5 failed attempts (15-minute window).
+- **Registration:** 10/minute, 50/hour.
+- **Password reset/change:** 5/minute, 20/hour.
+- **Search:** 120/minute, 2000/hour.
+- **Scan/enrichment:** 20/minute, 200/hour.
+- **X-Wines export:** 10/minute, 30/hour.
+- **Admin login:** 5/minute.
+- All paginated queries bounded by `MAX_USER_RESULTSET` (10,000) and `MAX_REFERENCE_RESULTSET` (5,000).
+- Database query timeouts configured: `serverSelectionTimeoutMS=5000`, `connectTimeoutMS=10000`, `socketTimeoutMS=30000`.
+- Upload size bounded by `max_upload_mb` config (default 10 MB) and nginx `client_max_body_size 10M`.
+
+#### 7. Session & Token Security
+
+- JWT tokens use HS256 with minimum 32-character secret key (enforced at startup).
+- Separate `WINEBOX_REGSTACK_JWT_SECRET` for regstack's purpose-derived keys.
+- Tokens include `jti` (UUID), `iat`, `exp`, `sub`, and `purpose` claims — all required on decode.
+- 2-hour token expiry.
+- Dual-layer revocation: per-token JTI blacklist + bulk user `tokens_invalidated_after` cutoff.
+- No token values logged anywhere in the codebase.
+- HSTS enabled in production: `max-age=31536000; includeSubDomains; preload`.
+- Verification tokens hashed (SHA-256) in database, not stored raw.
+
+#### 8. Security Headers
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `X-XSS-Protection: 1; mode=block`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `X-Permitted-Cross-Domain-Policies: none`
+- `Permissions-Policy` restricting camera, geolocation, microphone, etc.
+- `Content-Security-Policy`: `script-src 'self'` (no `unsafe-inline` for scripts), PostHog domains whitelisted, `frame-ancestors 'none'`, `object-src 'none'`.
+- CORS: empty origin list by default (same-origin only), explicit whitelist when configured.
+- Admin panel reuses the same `SecurityHeadersMiddleware`.
+- API docs (`/docs`, `/redoc`, `/openapi.json`) disabled in production for both main app and admin panel.
+
+#### 9. Data Exposure
+
+- `UserResponse` and `UserRead` models exclude `hashed_password` and internal fields.
+- Error messages are generic ("Invalid email or password") — no user enumeration.
+- Image serving endpoint returns uniform 404 for both "not found" and "not your image".
+- Admin `/info` endpoint intentionally omits MongoDB hostname.
+- Debug mode defaults to `False`; startup validation blocks production launch with debug enabled.
+- No stack traces, database connection strings, or file paths in error responses.
+- PostHog API key loaded from environment, not exposed beyond server-side calls.
+- Price tracker redacts sensitive fields (GPS, town, notes) for non-owner entries.
+
+#### 10. Git History Review
+
+- No commits since last review — HEAD is `6f325c7` (merge of 2026-05-18 security review).
+- No security-concerning changes in the last 30 commits (CI fixes, version bumps, security reviews, price tracker fix).
+- No secret files accidentally committed (`git log --diff-filter=A` clean).
+- `config/secrets.env.example` is the only secrets-adjacent file in git (contains only placeholders).
+
+#### 11. Infrastructure & Configuration
+
+- Production safety checks at startup: weak secret key blocked, localhost MongoDB warned, HTTPS enforcement checked.
+- Database safety check (`_check_database_safety()`) prevents non-production hosts from connecting to production MongoDB.
+- Secure defaults: `debug=False`, `enforce_https=False` (warned in production), `cors_origins=[]` (same-origin), `email_verification_required=True`.
+- Admin panel IP-restricted in nginx with explicit allowlist (no empty sections allowed).
+- API docs disabled in production for both apps.
+- nginx: `server_tokens off`, TLSv1.2/1.3 only, session tickets off, HSTS, HTTP-to-HTTPS redirect on all domains.
+- Systemd services hardened with `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`.
+
+#### 12. Third-Party Integration Security
+
+- Anthropic API key loaded from environment variables, not hardcoded. All calls have explicit timeouts (60-120 seconds).
+- PostHog API key loaded from secrets config. Analytics disabled by default (`posthog_enabled=False`).
+- AWS credentials (S3 backup, SES email) loaded from environment via named profile. Never logged.
+- regstack secrets (`WINEBOX_REGSTACK_JWT_SECRET`) properly managed via `secrets.env` and deploy pipeline.
+- No webhook endpoints that would require signature validation.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| :red_circle: CRITICAL | 0 |
+| :orange_circle: WARNING | 0 |
+| :yellow_circle: INFO | 7 |
+| :green_circle: CLEAN | 12 categories |
+
+**Date of review:** 2026-05-19
+**Reviewer:** Automated security audit (Claude Code)
+**Codebase version:** 0.7.85 (commit 6f325c7)
+
+### Comparison with Previous Review (2026-05-18)
+
+| Item | 2026-05-18 | 2026-05-19 | Status |
+|------|-----------|-----------|--------|
+| CRITICAL | 0 | 0 | Maintained |
+| WARNING | 0 | 0 | Maintained |
+| INFO | 7 | 7 | Carried forward |
+| INFO-1 (CVE tracking comments) | Carried forward | Carried forward | No change |
+| INFO-2 (exception messages in errors) | Carried forward | Carried forward | No change |
+| INFO-3 (E2E test secret key in tasks.py) | Carried forward | Carried forward | No change |
+| INFO-4 (password strength length-only) | Carried forward | Carried forward | No change |
+| INFO-5 (cairosvg unused) | Carried forward | Carried forward | No change |
+| INFO-6 (nginx vs app upload limit mismatch) | Carried forward | Carried forward | No change |
+| INFO-7 (cryptography version gap) | Carried forward | Carried forward | No change |
+
+### Changes Since Last Review
+
+- No code changes since last review. All dependency versions unchanged.
+- Dependency CVE databases re-checked: no new advisories affecting locked versions.
+- CVE-2026-2978/2979 confirmed to affect `fastapi-admin` (not used), not `fastapi` core.
+- CVE-2026-25580 confirmed to affect `pydantic-ai` (not used), not `pydantic` core.
+
+### Top 3 Priorities
+
+1. **Remove `cairosvg` if unused (INFO-5)** — reduces attack surface with no functionality loss.
+2. **Add CVE tracking comments to `pyproject.toml` (INFO-1)** — documentation consistency for `cairosvg`, `anthropic`, and `python-multipart`.
+3. **Plan `cryptography` upgrade to 48.x (INFO-7)** — stay closer to current for defence in depth.


### PR DESCRIPTION
## Summary

- **0 CRITICAL**, **0 WARNING**, **7 INFO** findings — clean bill of health
- No code changes since last review (2026-05-18); all dependency CVE databases re-checked
- CVE-2026-2978/2979 confirmed to affect `fastapi-admin` (not used), not `fastapi` core
- CVE-2026-25580 confirmed to affect `pydantic-ai` (not used), not `pydantic` core
- All 7 INFO items carried forward unchanged from previous reviews

## Top 3 Priorities

1. Remove `cairosvg` if unused (INFO-5) — reduces attack surface
2. Add CVE tracking comments to `pyproject.toml` (INFO-1) — documentation consistency
3. Plan `cryptography` upgrade to 48.x (INFO-7) — defence in depth

https://claude.ai/code/session_01FBRrizp88hZWfrm5e1sUur

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBRrizp88hZWfrm5e1sUur)_