### PR TITLE
Add prod-ssl task to renew the apex winebox.app cert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,14 @@ Bringing up `admin.winebox.app` from scratch (one-time sequence):
 
 The `[production]` section of `deploy/winebox-admin.toml` controls who can reach `admin.winebox.app`. Same semantics as the OAT allowlist.
 
+#### Renewing the apex landing-page cert
+
+`winebox.app` + `www.winebox.app` share one Let's Encrypt cert. If it expires (or to renew it by hand), run from a machine with SSH access to the droplet:
+
+    invoke prod-ssl                        # issue/renew the apex cert (briefly stops nginx)
+
+This also installs certbot renewal hooks (`/etc/letsencrypt/renewal-hooks/{pre,post}/`) that stop/start nginx around renewals, so unattended `certbot.timer` auto-renew no longer fails on the port-80 conflict. Verify afterwards with `uv run python scripts/check_certs.py`.
+
 Full production release (tests, version bump, PyPI publish, deploy):
 
     invoke deploy

--- a/tasks.py
+++ b/tasks.py
@@ -1323,6 +1323,9 @@ def rebuild_droplet(
 PROD_DROPLET_NAME = "winebox-production"
 PROD_DOMAIN = "booze.winebox.app"
 PROD_ADMIN_DOMAIN = "admin.winebox.app"
+# Apex landing-page cert. Shares one Let's Encrypt cert under
+# /etc/letsencrypt/live/winebox.app/ (see deploy/nginx-winebox.conf).
+PROD_APEX_DOMAINS = ("winebox.app", "www.winebox.app")
 PROD_ADMIN_SERVICE_FILE = "deploy/winebox-admin.service"
 PROD_WINEBOX_ADMIN = "/opt/winebox/.venv/bin/winebox-admin"
 
@@ -1521,6 +1524,67 @@ def prod_admin_ssl(ctx: Context) -> None:
     print(f"SSL configured for {PROD_ADMIN_DOMAIN}")
     print("\nNext: run `invoke deploy` (or `invoke deploy-only --version X`)")
     print("to publish the nginx config that references the new certs.")
+
+
+@task(name="prod-ssl")
+def prod_ssl(ctx: Context) -> None:
+    """Issue or renew the apex Let's Encrypt cert (winebox.app + www.winebox.app).
+
+    Covers the gap left by `prod-admin-ssl`/`oat-ssl`: the landing-page cert
+    at /etc/letsencrypt/live/winebox.app/ was only ever issued during the
+    one-time `deploy/initialise.py` setup, with no renewal task. Run this to
+    fix an expired apex cert.
+
+    The cert was issued with the standalone authenticator, whose unattended
+    auto-renew (`certbot.timer` -> `certbot renew`) fails whenever nginx is
+    holding port 80 — the likely reason this cert lapsed. To stop that from
+    recurring, this task also installs certbot renewal hooks that stop nginx
+    before a renewal and start it after. The hooks live in
+    /etc/letsencrypt/renewal-hooks/{pre,post}/ and apply to every cert on the
+    box, so all of them auto-renew cleanly from here on. certbot only runs the
+    hooks when a cert is actually due, so day-to-day uptime is unaffected.
+
+    Like the other SSL tasks this briefly stops nginx so certbot's standalone
+    HTTP-01 challenge can bind port 80, taking the public site down for the few
+    seconds certbot needs — run it during a quiet window.
+    """
+    prod_host = _resolve_prod_host()
+    domain_flags = " ".join(f"-d {d}" for d in PROD_APEX_DOMAINS)
+    print(f"Issuing/renewing SSL for {', '.join(PROD_APEX_DOMAINS)} on {prod_host}...")
+
+    from deploy.common import run_ssh
+
+    # Install renewal hooks so unattended `certbot renew` no longer fails on
+    # the port-80 conflict. Idempotent — re-running just rewrites the scripts.
+    run_ssh(
+        prod_host, "root",
+        [
+            "mkdir -p /etc/letsencrypt/renewal-hooks/pre "
+            "/etc/letsencrypt/renewal-hooks/post",
+            "printf '#!/bin/sh\\nsystemctl stop nginx\\n' "
+            "> /etc/letsencrypt/renewal-hooks/pre/stop-nginx.sh",
+            "printf '#!/bin/sh\\nsystemctl start nginx\\n' "
+            "> /etc/letsencrypt/renewal-hooks/post/start-nginx.sh",
+            "chmod +x /etc/letsencrypt/renewal-hooks/pre/stop-nginx.sh "
+            "/etc/letsencrypt/renewal-hooks/post/start-nginx.sh",
+        ],
+    )
+
+    run_ssh(prod_host, "root", "systemctl stop nginx", check=False)
+    try:
+        run_ssh(
+            prod_host, "root",
+            f"certbot certonly --standalone --non-interactive --agree-tos "
+            f"--email support@winebox.app {domain_flags}",
+        )
+    finally:
+        # Always bring nginx back up, even if certbot failed — otherwise the
+        # public site stays down until the operator notices.
+        run_ssh(prod_host, "root", "systemctl start nginx")
+
+    print(f"SSL issued/renewed for {', '.join(PROD_APEX_DOMAINS)}")
+    print("\nVerify from a machine with network access to the host:")
+    print("  uv run python scripts/check_certs.py --hosts winebox.app www.winebox.app")
 
 
 @task(name="generate-test-data")


### PR DESCRIPTION
## Summary

The `winebox.app` + `www.winebox.app` landing-page cert had no renewal path. The existing SSL tasks only cover `booze`/`admin`/`oat`/`oatadmin`; the apex cert was only ever issued during one-time `deploy/initialise.py` setup. This adds the missing renewal task and fixes the auto-renew root cause.

- **New `invoke prod-ssl` task** (`tasks.py`) — issues or renews the apex `winebox.app` + `www.winebox.app` cert the same disciplined, invoke-driven way as the other SSL tasks (briefly stops nginx for the standalone HTTP-01 challenge, always restarts it in a `finally`).
- **Installs certbot renewal hooks** (`/etc/letsencrypt/renewal-hooks/{pre,post}/`) that stop/start nginx around renewals. This fixes the likely root cause of the expiry: the standalone authenticator's unattended auto-renew (`certbot.timer`) fails whenever nginx holds port 80. After this runs once, every cert on the box auto-renews cleanly. certbot only runs the hooks when a cert is actually due, so day-to-day uptime is unaffected.
- **CLAUDE.md** — documents `invoke prod-ssl` alongside the other production ops commands.

## Test plan

- [ ] `invoke prod-ssl` from a machine with SSH access to the production droplet
- [ ] Confirm nginx comes back up and the apex site serves over HTTPS
- [ ] `uv run python scripts/check_certs.py` reports `winebox.app` / `www.winebox.app` valid
- [ ] Verify renewal hooks exist: `ls /etc/letsencrypt/renewal-hooks/{pre,post}/`

Note: the task couldn't be runtime-tested in the dev sandbox (invoke isn't installed there and outbound SSH to the droplet is blocked by the egress policy). It compiles and mirrors the working `prod-admin-ssl` task exactly, but has not been executed against a live host.

https://claude.ai/code/session_018TTv6vAQHUC9r9AN881kNg

---
_Generated by [Claude Code](https://claude.ai/code/session_018TTv6vAQHUC9r9AN881kNg)_