### PR TITLE
Test-DB cleanup (run-token sweep) + replace EOL claude-sonnet-4-20250514

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "winebox"
-version = "0.7.85"
+version = "0.7.86"
 description = "Wine Cellar Management Application with OCR label scanning"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tasks.py
+++ b/tasks.py
@@ -2262,3 +2262,39 @@ def push_secrets(ctx: Context) -> None:
             print(f"  {key}: FAILED")
 
     print(f"\nPushed {pushed} secrets, skipped {skipped}.")
+
+
+@task(name="clean-test-dbs")
+def clean_test_dbs(ctx: Context, dry_run: bool = False) -> None:
+    """Drop leftover winebox test databases from the local MongoDB.
+
+    Covers the shared test_winebox DB, isolated-fixture DBs
+    (test_winebox_isolated_*), and stale DBs left by older conftest
+    generations (test_winebox_<hex> per-test, test_winebox_<pid>
+    per-worker). Never touches winebox, winebox-oat, or any other
+    non-test database. Don't run this while a test run is active in
+    another worktree — it drops a live run's isolated DBs too.
+    """
+    from pymongo import MongoClient
+
+    client: MongoClient = MongoClient(
+        "mongodb://localhost:27017", serverSelectionTimeoutMS=2000
+    )
+    try:
+        victims = [
+            name
+            for name in client.list_database_names()
+            if name == "test_winebox" or name.startswith("test_winebox_")
+        ]
+        if not victims:
+            print("no leftover test databases")
+            return
+        for name in victims:
+            if dry_run:
+                print(f"would drop {name}")
+            else:
+                client.drop_database(name)
+        verb = "would drop" if dry_run else "dropped"
+        print(f"{verb} {len(victims)} test database(s)")
+    finally:
+        client.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,22 @@ TEST_MONGODB_URL = os.environ.get("TEST_MONGODB_URL", "mongodb://localhost:27017
 # Shared database name for all xdist workers
 SHARED_TEST_DB = "test_winebox"
 
+# Isolated-DB names carry a per-run token so pytest_sessionfinish can sweep
+# this run's leftovers — including DBs whose fixture teardown never ran
+# (worker crash, -x abort, Ctrl-C between create and drop). The token is
+# minted once in the xdist controller and inherited by workers via env, and
+# scopes the sweep to THIS run only: a parallel test run in another worktree
+# must never have its live DBs dropped out from under it.
+_RUN_TOKEN_ENV = "WINEBOX_TEST_RUN_TOKEN"
+
+
+def _run_token() -> str:
+    return os.environ[_RUN_TOKEN_ENV]
+
+
+def _isolated_db_prefix() -> str:
+    return f"test_winebox_isolated_{_run_token()}_"
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Drop shared test database before xdist workers start.
@@ -78,6 +94,7 @@ def pytest_configure(config: pytest.Config) -> None:
     Runs only in the master/controller process (workers have 'workerinput').
     Uses sync MongoClient since pytest_configure is synchronous.
     """
+    os.environ.setdefault(_RUN_TOKEN_ENV, uuid.uuid4().hex[:8])
     if not hasattr(config, "workerinput"):
         # Skip local-DB drop when running E2E against a remote target (OAT).
         # Remote E2E jobs don't need a local mongo at all.
@@ -89,6 +106,28 @@ def pytest_configure(config: pytest.Config) -> None:
         sync_client = MongoClient(url, serverSelectionTimeoutMS=2000)
         sync_client.drop_database(SHARED_TEST_DB)
         sync_client.close()
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Sweep this run's isolated DBs in case a fixture teardown never ran."""
+    if hasattr(session.config, "workerinput"):
+        return  # workers exit first; the controller does the sweep
+    if os.environ.get("WINEBOX_TEST_URL"):
+        return
+    from pymongo import MongoClient
+
+    prefix = _isolated_db_prefix()
+    url = os.environ.get("TEST_MONGODB_URL", "mongodb://localhost:27017")
+    try:
+        sync_client = MongoClient(url, serverSelectionTimeoutMS=2000)
+        try:
+            for name in sync_client.list_database_names():
+                if name.startswith(prefix):
+                    sync_client.drop_database(name)
+        finally:
+            sync_client.close()
+    except Exception as e:  # a failed sweep must not mask test results
+        print(f"\nwarning: could not sweep leftover isolated test DBs ({prefix}*): {e}")
 
 
 def pytest_unconfigure(config: pytest.Config) -> None:
@@ -304,7 +343,7 @@ async def isolated_db(mongo_client):
     the new instance. Safe because xdist runs tests sequentially within
     a worker.
     """
-    db_name = f"test_winebox_isolated_{os.getpid()}_{uuid.uuid4().hex[:8]}"
+    db_name = f"{_isolated_db_prefix()}{os.getpid()}_{uuid.uuid4().hex[:8]}"
     await init_db(
         mongo_client=mongo_client, mongodb_database=db_name, skip_indexes=True
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2928,7 +2928,7 @@ wheels = [
 
 [[package]]
 name = "winebox"
-version = "0.7.85"
+version = "0.7.86"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/winebox/__init__.py
+++ b/winebox/__init__.py
@@ -1,3 +1,3 @@
 """WineBox - Wine Cellar Management Application."""
 
-__version__ = "0.7.85"
+__version__ = "0.7.86"

--- a/winebox/services/vision.py
+++ b/winebox/services/vision.py
@@ -118,7 +118,7 @@ class ClaudeVisionService:
 
             # Call Claude API with vision
             message = client.messages.create(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-6",
                 max_tokens=1024,
                 messages=[
                     {
@@ -255,7 +255,7 @@ class ClaudeVisionService:
 
             # Call Claude API
             message = client.messages.create(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-6",
                 max_tokens=1024,
                 messages=[{"role": "user", "content": content}],
             )


### PR DESCRIPTION
## Summary

Two fixes, found together while applying regstack's test-database cleanup pattern to winebox.

### 1. Test runs no longer strand MongoDB databases

Local MongoDB had accumulated **72+ stale `test_winebox*` databases** from older conftest generations (per-test `test_winebox_{hex}`, per-worker `test_winebox_{pid}`, `test_winebox_gwN`). The only live leak path in current code is `isolated_db` DBs stranded when a run dies between create and drop.

- `isolated_db` names carry a per-run token (`WINEBOX_TEST_RUN_TOKEN`, minted in the xdist controller); `pytest_sessionfinish` sweeps the run's isolated DBs even when fixture teardown never ran. Token-scoped so parallel runs in other worktrees can't clobber each other; remote (`WINEBOX_TEST_URL`) runs skip it.
- New `inv clean-test-dbs` (with `--dry-run`) purges stale leftovers from hard-killed runs — used to drop the 72. Never touches `winebox`/`winebox-oat`.

### 2. Urgent: wine-label scanning model reaches EOL on Sunday

The suite's deprecation warnings revealed `vision.py` calling **`claude-sonnet-4-20250514`, end-of-life 2026-06-15** — scanning would have broken in three days. Swapped both call sites to `claude-sonnet-4-6` (documented drop-in replacement; plain vision+text request shape needs no other changes).

## Verification

Suite green before and after on this base: 758 passed, 7 pre-existing skips. Post-run MongoDB check shows no isolated DBs remain (only the shared `test_winebox`, dropped at next run start by design). The Claude SDK model-deprecation warnings are gone; the 3 remaining warnings originate inside slowapi/fastapi package internals (deprecated `HTTP_422_UNPROCESSABLE_ENTITY`), addressable only via a dependency bump.

Version bumped to 0.7.86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)