### PR TITLE
Security Review — 2026-06-18 — security-warning

### DIFF
--- a/docs/security-reports/2026-06-18.md
+++ b/docs/security-reports/2026-06-18.md
@@ -1,0 +1,292 @@
+# Security Review — 2026-06-18
+
+## Scope
+
+Comprehensive daily security audit of the WineBox project (FastAPI + MongoDB wine cellar application) covering:
+
+1. Dependency vulnerability check
+2. Hardcoded secrets scan
+3. Authentication & authorization audit
+4. NoSQL injection & query safety
+5. Input validation & injection prevention
+6. Rate limiting & DoS prevention
+7. Session & token security
+8. Security headers & CORS
+9. Data exposure review
+10. Git history review
+11. Infrastructure & configuration
+12. Third-party integration security
+
+**Notable context:** No application code changes since the last review (2026-06-17). HEAD is at `53b9155` (version 0.7.86). This review conducted a deeper audit of rate limiting enforcement and dependency CVEs, surfacing three WARNING-level findings not identified in previous reviews.
+
+---
+
+## Findings
+
+### :red_circle: CRITICAL
+
+None.
+
+### :orange_circle: WARNING
+
+**WARNING-1: SlowAPI `default_limits` not enforced — middleware not registered**
+
+- **File:** `winebox/main.py:30-34,207-209`
+- **Detail:** The `Limiter` is created with `default_limits=["60/minute"]` and stored on `app.state.limiter`, but `SlowAPIMiddleware` (or `SlowAPIASGIMiddleware`) is never added to the app. In slowapi, `default_limits` are only checked when the middleware intercepts requests. Without the middleware, only endpoints with explicit `@limiter.limit()` decorators are rate-limited. Endpoints without decorators have **zero rate limiting**.
+- **Affected endpoints (no rate limit):**
+  - `POST /api/wines/record` — Most expensive endpoint: image upload + Claude Vision + X-Wines enrichment + DB writes
+  - `POST /api/wines/met` — Same pipeline as record
+  - `POST /api/import/{batch_id}/process` and `/process-stream` — Bulk processing, creates many wines
+  - `DELETE /api/wines` (delete_all) — Cascading bulk delete across 6+ collections
+  - `POST /api/cases`, `POST /api/bottles` — Write endpoints
+  - `GET /api/cellar/summary`, `GET /api/cellar/grouped` — Aggregation pipelines loading up to 10,000 documents
+  - All `/api/reference/*` endpoints — Public, no auth required
+  - `GET /api/xwines/wines/{id}`, `/stats`, `/types`, `/countries` — Public, no auth
+  - `POST /api/import/upload-parsed` — Can trigger Claude AI mapping
+- **Endpoints that ARE rate-limited (have explicit decorators):** `/api/search`, `/api/xwines/search`, `/api/wines/scan`, `/api/wines/enrich`, `/api/export/*`, `/api/import/upload`, `/api/xwines/export`, `/api/demo/install`, `/api/prices`, all auth endpoints, admin data endpoints.
+- **Impact:** An authenticated user can invoke Claude Vision at unlimited rate via the record endpoint, driving up API costs. Public reference endpoints can be abused for DoS without authentication.
+- **Fix:** Add `from slowapi.middleware import SlowAPIASGIMiddleware` and `app.add_middleware(SlowAPIASGIMiddleware)` after the existing `app.state.limiter` assignment. Then add explicit tighter limits to the record/met/import-process endpoints (10-20/minute) matching the scan endpoint's pattern.
+- **Status:** New finding.
+
+**WARNING-2: python-multipart 0.0.28 affected by CVE-2026-53539 (quadratic-time DoS)**
+
+- **File:** `uv.lock` — python-multipart pinned at 0.0.28; patch is in 0.0.30
+- **CVE:** CVE-2026-53539 — Quadratic-time querystring parsing with semicolon separators. A 1 MB payload causes O(B^2) byte comparisons, enabling CPU denial of service. FastAPI uses python-multipart for all form/multipart parsing, so every endpoint accepting form data (`/api/wines/record`, `/api/wines/met`, `/api/wines/scan`, `/api/import/upload`, `/api/prices`) is exposed.
+- **Impact:** Medium-High. Unlike the other dependency CVEs (Starlette, PyJWT) which have architectural mitigations, this DoS vector is directly exploitable against any form-data endpoint. The nginx `client_max_body_size 10M` limits payload size but a 10 MB semicolon-delimited string could still cause significant CPU burn.
+- **Fix:** Bump `python-multipart>=0.0.30` in `pyproject.toml` and run `uv lock --upgrade-package python-multipart`.
+- **Status:** New finding. Previous reviews only tracked CVE-2026-40347 and CVE-2026-24486 (both patched at 0.0.28).
+
+**WARNING-3: Import processor exposes raw exception messages to client**
+
+- **Files:** `winebox/services/import_service/processor.py:159-161,268-273`
+- **Detail:** The import processor catches broad `except Exception as e` and appends `str(e)` to the batch error list, which is returned to the client via `ImportResultResponse`. A database connectivity issue, `ServerSelectionTimeoutError`, `OperationFailure`, or other unexpected MongoDB error would have its raw message surfaced to the user, potentially leaking connection details, collection names, or internal database state.
+- **Impact:** Information disclosure under error conditions. Normal operations are not affected.
+- **Fix:** Replace `str(e)` with a generic message (e.g., "Failed to process row N") and log the actual exception server-side: `logger.exception("Import row %d failed", row_index)`.
+- **Status:** New finding. INFO-2 in previous reviews covered four *specific* exception types with controlled messages; this finding is about the *broad* `except Exception` catch in a different code path.
+
+### :yellow_circle: INFO (Best practice recommendations)
+
+**INFO-1 through INFO-25:** All 25 INFO-level findings from the 2026-06-17 review carry forward unchanged. Key items:
+
+| ID | Summary | File(s) |
+|----|---------|---------|
+| INFO-1 | CVE tracking comments missing for 3 deps | `pyproject.toml` |
+| INFO-2 | Exception messages in 4 HTTP errors (controlled types) | `import_router.py`, `record.py`, `met.py`, `checkout.py` |
+| INFO-3 | E2E test secret keys in tasks.py | `tasks.py:283,2060` |
+| INFO-4 | Password strength is length-only (NIST-compliant) | regstack `PasswordStr` |
+| INFO-5 | `cairosvg` dependency appears unused | `pyproject.toml:48` |
+| INFO-6 | nginx `client_max_body_size 10M` vs app 25MB | `deploy/nginx-winebox.conf:191` |
+| INFO-7 | `cryptography` 46.0.7 is 3 major versions behind 49.0.0 | `uv.lock` |
+| INFO-8 | Starlette CVE-2026-48710 (BadHost) — not exploitable | `uv.lock` |
+| INFO-9 | Cascading delete missing `owner_id` scope | `crud.py:188-189` |
+| INFO-10 | Admin delete_user skips CellarEvent/CellarItem cleanup | `admin.py:303-330` |
+| INFO-11 | Several Pydantic fields missing `max_length` | Various schemas |
+| INFO-12 | Vision endpoints rely on global rate limit only | `record.py`, `met.py` |
+| INFO-13 | Admin deactivation doesn't bump `tokens_invalidated_after` | `admin.py:265-272` |
+| INFO-14 | Deprecated `X-XSS-Protection: 1; mode=block` | `main.py:46` |
+| INFO-15 | Admin logout uses `RequireAuth` not `RequireAdmin` | `admin/routers/auth.py:69` |
+| INFO-16 | Four `to_list()` calls lack explicit length bounds | Various services |
+| INFO-17 | nginx configs lack OCSP stapling | `deploy/nginx-*.conf` |
+| INFO-18 | PyJWT 2.12.1 has 5 CVEs — none exploitable in WineBox | `uv.lock` |
+| INFO-19 | aiohttp CVE-2026-47265 — not exploitable (transitive) | `uv.lock` |
+| INFO-20 | urllib3 CVE-2026-44431 — not exploitable | `uv.lock` |
+| INFO-21 | aiohttp CVE-2026-34993 — not exploitable | `uv.lock` |
+| INFO-22 | python-dotenv CVE-2026-28684 — not exploitable | `uv.lock` |
+| INFO-23 | idna CVE-2026-45409 — not exploitable | `uv.lock` |
+| INFO-24 | Admin `escapeHtml()` doesn't escape quotes | `admin.js:56-61` |
+| INFO-25 | MongoDB URL unmasked in 2 archived scripts | `scripts/migrations/`, `scripts/archive/` |
+
+**INFO-26: Admin app has no global default rate limit**
+
+- **File:** `winebox/admin/main.py:58`
+- **Detail:** The admin app creates `Limiter(key_func=get_remote_address)` with no `default_limits` parameter and no `SlowAPIMiddleware`. Admin mutation endpoints (create user, activate, deactivate, make-admin, remove-admin, verify, delete) have zero rate limiting. The login and data-read endpoints have explicit `@limiter.limit()` decorators and are protected.
+- **Impact:** Very low — admin panel is IP-restricted at nginx. An attacker would need to be on the allowlisted IP.
+- **Status:** New finding.
+
+**INFO-27: No global `InvalidId` exception handler**
+
+- **Files:** `winebox/main.py`, `winebox/admin/main.py`
+- **Detail:** Both apps register only `RateLimitExceeded` exception handlers. There is no global handler for `bson.errors.InvalidId`. All current ObjectId parsing sites have local try/except, but the base `MongoDocument.get()` method (`db/document.py:229`) does not wrap `ObjectId()` — a future caller who forgets try/except would produce a 500 error. Adding a global `InvalidId` -> 404 handler would provide defense-in-depth.
+- **Status:** New finding.
+
+**INFO-28: Background enrichment tasks can be triggered repeatedly without dedup**
+
+- **File:** `winebox/routers/wines/enrichment.py:91`
+- **Detail:** `asyncio.create_task(enrich_unenriched_wines(current_user.id))` is called on every enrichment request with no check for whether an enrichment task is already in progress for the user. A user could trigger 20 concurrent tasks per minute (the enrichment endpoint's rate limit), each processing wines in batches of 50 with potential Claude API calls.
+- **Status:** New finding.
+
+**INFO-29: `User.hashed_password` lacks `Field(exclude=True)`**
+
+- **File:** `winebox/models/user.py:37`
+- **Detail:** The `hashed_password` field is a regular Pydantic field with no exclusion annotation. All current user-returning endpoints manually construct response dicts, so no leak occurs today. However, a future developer calling `user.model_dump()` in a new endpoint would inadvertently leak the password hash. Adding `Field(exclude=True)` would provide structural safety.
+- **Status:** New finding.
+
+**INFO-30: `SecretsConfig` uses `str` instead of `SecretStr`**
+
+- **File:** `winebox/config/schema.py:103-114`
+- **Detail:** Secret fields (`secret_key`, `anthropic_api_key`, `aws_secret_access_key`, etc.) are typed as `str | None` rather than `SecretStr`. A stray `settings.secrets.model_dump()` or `repr()` would expose secrets in plaintext. The class is only accessed internally and never serialized to API responses.
+- **Status:** New finding.
+
+**INFO-31: No per-query `maxTimeMS` on aggregation pipelines**
+
+- **Files:** All router and service files using `.aggregate()`
+- **Detail:** While `socketTimeoutMS=30000` provides a connection-level backstop (`database.py:47`), no individual query or aggregation sets `max_time_ms()`. Expensive aggregations (cellar summary's 9-sub-pipeline `$facet`, X-Wines regex searches) could each run up to 30 seconds.
+- **Status:** New finding.
+
+**INFO-32: Price-tracker photo serving lacks `resolve()` containment check**
+
+- **File:** `winebox/routers/price_tracker.py:431-460`
+- **Detail:** The `get_price_photo()` endpoint rejects `/`, `\`, and `..` in filenames (string-based check) but does not use `resolve()` + `relative_to()` to verify the final path stays inside the storage directory, unlike the image endpoint's `_safe_resolve()`. Ownership verification provides a second layer, but a symlink inside the storage directory could bypass the string check.
+- **Status:** New finding.
+
+---
+
+### :green_circle: CLEAN (Passed review)
+
+#### 1. Dependency Vulnerability Check
+
+All key dependencies at patched versions (unchanged from 2026-06-17). New CVE assessment:
+
+| Package | Locked | New Finding |
+|---------|--------|-------------|
+| python-multipart | 0.0.28 | **CVE-2026-53539 — NOT patched** (see WARNING-2) |
+| All others | Same | No new CVEs discovered |
+
+#### 2. Hardcoded Secrets Scan
+
+- No API keys, connection strings, passwords, private keys, or JWTs found in source code.
+- `.gitignore` properly covers `.env`, `secrets.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- `git ls-files` confirms no sensitive files tracked (only `config/secrets.env.example`).
+- No secrets found in git history via `git log --diff-filter=A`.
+
+#### 3. Authentication & Authorization Audit
+
+All 80+ endpoints audited:
+
+- All user-data endpoints require `RequireAuth` with `owner_id`/`cellar_id` filtering.
+- All admin endpoints use `RequireAdmin`.
+- Password changes invalidate tokens via dual mechanism (JTI blacklist + `tokens_invalidated_after`).
+- Constant-time Argon2id password verification via pwdlib.
+- JWT tokens include `jti`, `iat`, `exp`, `sub`, `purpose` — all validated on decode.
+- Purpose-separated derived keys (session, password_reset, email_change) via HMAC-SHA256.
+- Anti-enumeration: forgot-password returns same response regardless of email existence.
+
+#### 4. NoSQL Injection & Query Safety
+
+- No unsafe MongoDB operators (`$where`, `$expr`, `$accumulator`, `$function`) in application code.
+- All regex searches use `re.escape()` (confirmed in `search_service.py`, `reference.py`, `xwines.py`, `xwines_enrichment.py`).
+- All ObjectId parsing wrapped in `try/except InvalidId`.
+- All API inputs validated via Pydantic models — no raw dict or untyped JSON bodies.
+- `$in` arrays sourced from internal data, never directly from unbounded user input.
+- No MongoDB operator injection possible: FastAPI + Pydantic coerce all inputs to scalar types.
+
+#### 5. Input Validation & Injection Prevention
+
+- File uploads validated: magic bytes, extension whitelist, size limits, UUID filenames.
+- Path traversal prevented in main image serving (`_safe_resolve()` with `resolve()` + `relative_to()`).
+- Jinja2 email templates use `autoescape=True`. No `|safe` filter. No `Markup()`.
+- No `eval()`, `exec()`, `__import__()` in application code.
+- Search queries capped at 200 characters.
+- Main app `escapeHtml()` escapes all 5 HTML special characters.
+- CSP with `script-src 'self'` — no `unsafe-inline` for scripts.
+
+#### 6. Rate Limiting & DoS Prevention (decorated endpoints)
+
+Endpoints with explicit rate limits are correctly configured:
+
+| Endpoint | Limit |
+|----------|-------|
+| Login | 30/min, 200/hr + lockout |
+| Registration | 10/min, 50/hr |
+| Password reset/change | 5/min, 20/hr |
+| Search | 120/min, 2000/hr |
+| Scan/enrichment | 20/min, 200/hr |
+| Exports | 10/min, 30/hr |
+| Import upload | 10/min, 30/hr |
+| Admin login | 5/min |
+
+Database timeouts configured: `serverSelectionTimeoutMS=5000`, `connectTimeoutMS=10000`, `socketTimeoutMS=30000`.
+
+#### 7. Session & Token Security
+
+- HS256 with minimum 32-character secret (enforced at startup).
+- 2-hour token expiry.
+- Dual-layer revocation: per-token JTI blacklist + bulk `tokens_invalidated_after`.
+- Verification tokens hashed (SHA-256) in database.
+- No token values logged anywhere.
+- HSTS enabled in production.
+
+#### 8. Security Headers
+
+- `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, CSP, HSTS, `Referrer-Policy`, `Permissions-Policy`.
+- CORS: empty origin list by default (same-origin only).
+- API docs disabled in production.
+- No inline scripts in any HTML template.
+- nginx: `server_tokens off`, TLSv1.2/1.3 only, strong cipher suite.
+
+#### 9. Data Exposure
+
+- User-returning endpoints manually construct response dicts, excluding `hashed_password`.
+- Generic error messages — no user enumeration.
+- Debug mode disabled in production, startup validation blocks insecure configs.
+- No stack traces or file paths in error responses.
+- Price tracker redacts sensitive fields (GPS, notes, photos) for non-owners.
+
+#### 10. Git History Review
+
+- No code changes since last review. HEAD at `53b9155`.
+- No secret files in git history.
+- No force pushes or concerning patterns.
+
+#### 11. Infrastructure & Configuration
+
+- Production safety checks at startup (weak key blocked, debug blocked, HTTPS checked).
+- Database safety check prevents non-production hosts connecting to production MongoDB.
+- Admin panel IP-restricted with fail-closed allowlist.
+- Systemd: `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`.
+- MongoDB connection pool bounded (`minPoolSize=10`, `maxPoolSize=100`).
+
+#### 12. Third-Party Integration Security
+
+- All external API clients (Anthropic, PostHog, DigitalOcean) have explicit timeouts.
+- No SSRF vectors — no endpoint accepts user-supplied URLs for server-side fetching.
+- No webhook endpoints requiring signature validation.
+
+---
+
+## :bar_chart: Summary
+
+| Severity | Count |
+|----------|-------|
+| :red_circle: CRITICAL | 0 |
+| :orange_circle: WARNING | 3 |
+| :yellow_circle: INFO | 32 (25 carried forward + 7 new) |
+| :green_circle: CLEAN | 12 categories |
+
+**Date of review:** 2026-06-18
+**Reviewer:** Automated security audit (Claude Code)
+**Codebase version:** 0.7.86 (commit 53b9155)
+
+### Comparison with Previous Review (2026-06-17)
+
+| Item | 2026-06-17 | 2026-06-18 | Status |
+|------|-----------|-----------|--------|
+| CRITICAL | 0 | 0 | Maintained |
+| WARNING | 0 | 3 | +3 new findings from deeper analysis |
+| INFO | 25 | 32 | +7 new findings |
+
+### Changes Since Last Review
+
+- **No application code changes** since last review (HEAD at `53b9155`).
+- **All dependency versions unchanged.**
+- **Three new WARNING findings** from deeper rate-limiting and dependency analysis:
+  - **WARNING-1:** `SlowAPIMiddleware` not registered — `default_limits` not enforced on ~40% of endpoints. Previous reviews incorrectly assumed the global 60/min was working.
+  - **WARNING-2:** python-multipart CVE-2026-53539 (quadratic DoS) — new CVE not tracked in previous reviews. Requires upgrade to >=0.0.30.
+  - **WARNING-3:** Import processor leaks raw exception messages — distinct from INFO-2's controlled exception types.
+- **Seven new INFO findings** (INFO-26 through INFO-32) from deeper audit of admin rate limiting, exception handling, data model safety, query timeouts, and path traversal patterns.
+
+### Top 3 Priorities
+
+1. **Register `SlowAPIMiddleware` and add explicit rate limits to expensive endpoints (WARNING-1)** — One-line middleware registration immediately restores the intended 60/min global default. Then add explicit 10-20/min limits to record/met/import-process endpoints.
+2. **Upgrade python-multipart to >=0.0.30 (WARNING-2)** — Closes CVE-2026-53539 (quadratic DoS on all form-data endpoints). Single dependency bump, no code changes needed.
+3. **Sanitize import processor error messages (WARNING-3)** — Replace `str(e)` with generic messages and log the actual exception server-side.


### PR DESCRIPTION
## Summary

3 WARNING-level findings from deeper rate-limiting and dependency analysis. No code changes since last review — these are pre-existing conditions surfaced by more thorough audit methodology.

### WARNING findings

- **WARNING-1: SlowAPIMiddleware not registered** — `default_limits=["60/minute"]` is not enforced on ~40% of endpoints (including expensive ones like `POST /api/wines/record` which triggers Claude Vision). Only endpoints with explicit `@limiter.limit()` decorators are rate-limited.
- **WARNING-2: python-multipart 0.0.28 CVE-2026-53539** — Quadratic-time DoS via semicolon-delimited form parsing. All form-data endpoints exposed. Fixed in >=0.0.30.
- **WARNING-3: Import processor raw exception leak** — Broad `except Exception as e` in `processor.py` surfaces `str(e)` to client via batch errors, could leak DB details under error conditions.

### INFO findings

- 25 carried forward from previous review
- 7 new (INFO-26 through INFO-32): admin rate limits, global InvalidId handler, background task dedup, User model defense-in-depth, SecretsConfig typing, query timeouts, path traversal containment

### Recommended priority fixes

1. Register `SlowAPIASGIMiddleware` (one-line fix) + add explicit limits to record/met/import endpoints
2. Bump `python-multipart>=0.0.30` in pyproject.toml
3. Replace `str(e)` with generic messages in import processor

---
_Generated by [Claude Code](https://claude.ai/code/session_014Gs7du1Fr6BNS4exAuA8j1)_