### PR TITLE
Security Review — 2026-06-27 — security-clean

### DIFF
--- a/docs/security-reports/2026-06-27.md
+++ b/docs/security-reports/2026-06-27.md
@@ -1,0 +1,537 @@
+# Security Review — 2026-06-27
+
+## Scope
+
+Comprehensive daily security audit of the WineBox project (FastAPI + MongoDB wine cellar application) covering:
+
+1. Dependency vulnerability check
+2. Hardcoded secrets scan
+3. Authentication & authorization audit
+4. NoSQL injection & query safety
+5. Input validation & injection prevention
+6. Rate limiting & DoS prevention
+7. Session & token security
+8. Security headers & CORS
+9. Data exposure review
+10. Git history review
+11. Infrastructure & configuration
+12. Third-party integration security
+
+**Notable context:** No application code changes since the last review (2026-06-26). HEAD is at `262562b` (version 0.7.86). Dependency versions unchanged. All 32 INFO-level findings from the previous review carried forward. One new INFO-level finding added (INFO-33).
+
+---
+
+## Findings
+
+### :red_circle: CRITICAL
+
+None.
+
+### :orange_circle: WARNING
+
+None.
+
+### :yellow_circle: INFO (Best practice recommendations)
+
+**INFO-1: CVE tracking comments missing for three dependencies**
+
+- **File:** `pyproject.toml`
+- **Detail:** Three dependencies have known CVEs that are already patched by the current version pins, but lack the tracking comments used elsewhere in the file:
+  - `cairosvg>=2.9.0` — CVE-2026-31899 (recursive `<use>` element DoS, CVSS 7.5)
+  - `anthropic>=0.96.0` — CVE-2026-34450 + CVE-2026-34452 (memory tool file permissions and TOCTOU, not used by WineBox)
+  - `python-multipart>=0.0.26` — CVE-2026-40347 (multipart preamble DoS)
+- **Impact:** No security risk — versions are already safe. Documentation consistency issue.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-2: Exception messages exposed in HTTP error details (4 locations)**
+
+- **Files:**
+  - `winebox/routers/import_router.py:180` — `detail=str(e)` for `ValueError`
+  - `winebox/routers/wines/record.py:152` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/met.py:157` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/checkout.py:96` — `detail=str(e)` for `CellarDebitError`
+- **Detail:** All four catch specific exception types (not generic `Exception`), and the messages are user-facing parsing errors or domain-specific errors with controlled messages. No internal paths, database names, or stack traces are leaked.
+- **Impact:** Minimal — these are controlled error messages from known exception types.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-3: E2E test secret keys hardcoded in tasks.py**
+
+- **File:** `tasks.py` (lines 283, 2060)
+- **Values:** `"e2e-test-secret-key-not-for-production-use-1234567890"` and `"oat-e2e-test-secret-key-1234567890"`
+- **Detail:** Clearly labelled test-only values used for isolated E2E test environments. Not used in production. Low risk.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-4: Password strength validation is length-only (8 characters minimum)**
+
+- **File:** regstack's `PasswordStr` type (min_length=8, max_length=128)
+- **Detail:** Registration and password change enforce a minimum of 8 characters but do not require complexity. This is acceptable per NIST SP 800-63B guidance (which discourages complexity rules).
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-5: `cairosvg` dependency appears unused**
+
+- **File:** `pyproject.toml` line 48
+- **Detail:** `cairosvg>=2.9.0` is declared as a dependency but is not imported anywhere in the codebase (`winebox/`, `scripts/`, `tests/`). Keeping an unused dependency increases attack surface without benefit.
+- **Recommendation:** Confirm whether CairoSVG is needed for a planned feature; if not, remove it from dependencies.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-6: nginx `client_max_body_size` is lower than the import upload app-level limit**
+
+- **Files:** `deploy/nginx-winebox.conf:191` (`client_max_body_size 10M`), `winebox/routers/import_router.py:143` (`MAX_IMPORT_BYTES = 25 MB`)
+- **Detail:** The application claims to accept spreadsheet imports up to 25 MB, but nginx rejects requests above 10 MB. Uploads between 10-25 MB will fail with a nginx 413 error before reaching the application.
+- **Impact:** No security risk — this is a functionality gap, not a vulnerability. The lower nginx limit is actually more conservative.
+- **Recommendation:** Either raise `client_max_body_size` to 25M or lower the application limit to match 10M.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-7: `cryptography` package is 3 major versions behind latest**
+
+- **File:** `uv.lock` — pinned at 46.0.7, latest is 49.0.0 (released 2026-06-12)
+- **Detail:** All known CVEs (CVE-2026-39892, CVE-2026-34073, CVE-2026-26007) are patched at 46.0.7. The version gap itself is not a vulnerability, but staying current is advisable for defence in depth. Version 49.0.0 is the latest release.
+- **Recommendation:** Plan upgrade to 49.x in a future maintenance cycle.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-8: Starlette 0.50.0 is affected by CVE-2026-48710 (BadHost) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — starlette pinned at 0.50.0; patch is in starlette 1.0.1
+- **CVE:** CVE-2026-48710 — Starlette reconstructs `request.url` from the HTTP Host header without validation. A malformed Host header can cause `request.url.path` to differ from the path the ASGI server actually routed, allowing middleware that makes security decisions based on `request.url.path` to be bypassed.
+- **Impact on WineBox: None.** WineBox does not use path-based auth middleware. Authentication is enforced via FastAPI dependency injection (`RequireAuth`, `RequireAdmin`) on individual route handlers, which operate on the ASGI scope path (the correctly-routed path), not `request.url.path`. The only `request.url` usage is `request.url.query` in two redirect handlers (`main.py:265,270`), which poses no auth bypass risk. Additionally, nginx normalises Host headers in production, providing a second layer of protection.
+- **Upgrade path:** FastAPI 0.128.1 constrains starlette to `<0.51.0,>=0.40.0`. Upgrading to starlette 1.0.1 requires upgrading FastAPI to >=0.136.0 (latest 0.136.3).
+- **Recommendation:** Plan a coordinated FastAPI + Starlette upgrade in a future maintenance cycle. The vulnerability is not exploitable in WineBox's current architecture, but upgrading removes the theoretical risk and keeps the stack current.
+- **Status:** Carried forward from 2026-05-27 review.
+
+**INFO-9: Cascading delete in `delete_wine` does not scope by `owner_id`**
+
+- **File:** `winebox/routers/wines/crud.py:188-189`
+- **Detail:** When deleting a wine, the cascading deletion of `CellarEvent` and `Transaction` documents filters by `wine_id` but not by `owner_id`/`cellar_id`. The wine itself is already confirmed as owned by the current user via `get_wine_or_404` (line 177), and MongoDB ObjectIds are globally unique, so there is zero practical risk. However, adding `owner_id` to the cascade filter would be a defence-in-depth improvement.
+- **Impact:** None — the ownership check on the wine itself prevents any cross-user deletion.
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-10: Admin `delete_user` does not clean up `CellarEvent` or `CellarItem` documents**
+
+- **File:** `winebox/admin/routers/admin.py:303-330`
+- **Detail:** The admin delete-user endpoint removes wines, transactions, import batches, and raw uploads, but does not remove `CellarEvent` or `CellarItem` documents for the deleted user. This leaves orphaned data in the database. No security risk — the orphaned documents are scoped by `cellar_id`/`owner_id` and cannot be accessed by other users.
+- **Recommendation:** Add `CellarEvent` and `CellarItem` cleanup to the delete cascade.
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-11: Several Pydantic fields missing `max_length` constraints**
+
+- **Files:**
+  - `winebox/admin/routers/admin.py:193` — `CreateUserRequest.password` has no `max_length` (Argon2id will hash any length; behind `RequireAdmin`)
+  - `winebox/schemas/reference.py:189,206` — `WineScoreBase.notes` has no `max_length`
+  - `winebox/schemas/reference.py:186,203` — `WineScoreBase.score_type` has no `max_length` (mitigated by handler-level validation against `VALID_SCORE_TYPES`)
+  - `winebox/schemas/reference.py:173` — `WineGrapeBlendUpdate.grapes` list has no `max_length`
+  - `winebox/schemas/import_schemas.py:36` — `ColumnMappingRequest.mapping` dict has no size constraint (bounded by CSV header count elsewhere)
+  - `winebox/schemas/wine.py:63,66,69` — `WineUpdate.wine_type`, `price_tier`, `producer_type` have no `max_length`
+- **Detail:** These fields accept unbounded input at the Pydantic layer. All are behind `RequireAuth` or `RequireAdmin`, and most are bounded by application logic elsewhere. The global rate limit (60/min) and MongoDB socket timeout (30s) provide baseline protection.
+- **Impact:** Very low — attacker must be authenticated, and practical exploitation is limited by rate limiting and timeouts.
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-12: Vision-calling write endpoints rely on global rate limit only**
+
+- **Files:** `winebox/routers/wines/record.py`, `winebox/routers/wines/met.py`
+- **Detail:** The `POST /api/wines/record` and `POST /api/wines/met` endpoints can trigger Claude Vision API calls (expensive external service), but rely only on the global 60/minute rate limit rather than having their own tighter limits like the scan endpoint (20/minute). The `/api/wines/scan` endpoint has an explicit 20/minute limit for the same Vision functionality.
+- **Impact:** Low — an authenticated user could consume more Vision API quota than intended at 60 requests/minute vs the 20/minute cap on the equivalent scan endpoint.
+- **Recommendation:** Add explicit rate limits matching the scan endpoint (20/minute; 200/hour).
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-13: Admin deactivation does not bump `tokens_invalidated_after`**
+
+- **File:** `winebox/admin/routers/admin.py:265-272`
+- **Detail:** When an admin deactivates a user, the endpoint sets `is_active = False` but does not bump `tokens_invalidated_after`. This is not a bypass — regstack's auth dependency checks `user.is_active` on every authenticated request (`regstack/auth/dependencies.py:174`), so the deactivated user is effectively blocked immediately on their next request. However, bumping `tokens_invalidated_after` would add belt-and-suspenders redundancy, ensuring the token itself is rejected even if the `is_active` check were ever refactored.
+- **Impact:** None in current architecture — `is_active` check provides immediate blocking.
+- **Recommendation:** Consider setting `tokens_invalidated_after = now` alongside `is_active = False` for defence-in-depth.
+- **Status:** Carried forward from 2026-05-29 review.
+
+**INFO-14: Deprecated `X-XSS-Protection` header set to `1; mode=block`**
+
+- **File:** `winebox/main.py:46`
+- **Detail:** The `X-XSS-Protection` header is deprecated and has been removed from modern browsers. Setting it to `1; mode=block` could theoretically introduce XSS vulnerabilities in older browsers by enabling the browser's buggy XSS auditor. Modern security guidance recommends setting it to `0` or removing it entirely. The strong Content-Security-Policy already provides comprehensive XSS protection.
+- **Impact:** Negligible — the strong CSP is the primary XSS defence. This is a best-practice alignment issue.
+- **Recommendation:** Change to `X-XSS-Protection: 0` or remove the header.
+- **Status:** Carried forward from 2026-05-29 review.
+
+**INFO-15: Admin logout uses `RequireAuth` instead of `RequireAdmin`**
+
+- **File:** `winebox/admin/routers/auth.py:69-70`
+- **Detail:** The `/api/auth/logout` endpoint in the admin panel uses `RequireAuth` rather than `RequireAdmin`. This means a non-admin authenticated user who somehow obtains access to the admin panel (behind an IP allowlist at the nginx layer) could invoke the logout endpoint, which only revokes their own token — a self-destructive, non-escalating operation.
+- **Impact:** Negligible — the admin panel is IP-restricted, and logout only affects the caller's own session.
+- **Recommendation:** Change to `RequireAdmin` for consistency with the rest of the admin panel.
+- **Status:** Carried forward from 2026-05-29 review.
+
+**INFO-16: Four `to_list()` calls lack explicit length bounds**
+
+- **Files:**
+  - `winebox/services/cellar_event_view.py:242` — `list_wine_transactions()` calls `.to_list()` with no length limit, fetching all events for a wine without pagination.
+  - `winebox/routers/bottles.py:190` — `get_item_events()` calls `CellarEvent.find(...).sort(...).to_list()` with no length limit for a single item's event history.
+  - `winebox/services/cellar_inventory.py:88` — `cursor.to_list(length=None)` for cellar items scoped to a single user's in-stock items.
+  - `winebox/services/cellar_debit.py:142` — `.to_list(length=None)` for cellar items matching a wine, scoped to one user + one wine.
+- **Detail:** All queries are scoped to a single wine/item/user and naturally produce small result sets. However, adding `length=MAX_USER_RESULTSET` would provide defence-in-depth against any future data shape that could inflate result counts.
+- **Impact:** Very low — result sets are naturally small due to scoping.
+- **Recommendation:** Add explicit `length=MAX_USER_RESULTSET` to all four `to_list()` calls.
+- **Status:** Carried forward from 2026-05-31 review.
+
+**INFO-17: nginx configs lack OCSP stapling directives**
+
+- **Files:** `deploy/nginx-winebox.conf`, `deploy/nginx-winebox-oat.conf`
+- **Detail:** Neither production nor OAT nginx configs include `ssl_stapling on;`, `ssl_stapling_verify on;`, or `ssl_stapling_resolver` directives. OCSP stapling improves TLS handshake performance and avoids client-side OCSP soft-fail.
+- **Impact:** Low — browsers fall back to direct OCSP checks or soft-fail. No authentication or encryption impact. This is a performance and privacy improvement.
+- **Recommendation:** Add `ssl_stapling on; ssl_stapling_verify on; resolver 1.1.1.1 8.8.8.8 valid=300s;` to both nginx TLS server blocks.
+- **Status:** Carried forward from 2026-06-04 review.
+
+**INFO-18: PyJWT 2.12.1 is affected by five CVEs — none exploitable in WineBox**
+
+- **File:** `uv.lock` — pyjwt pinned at 2.12.1; all five are patched in pyjwt 2.13.0
+- **CVEs affecting PyJWT 2.12.1:**
+  - **CVE-2026-48526** (Algorithm confusion) — When decoding tokens using a raw JWK string while supporting mixed algorithm families, PyJWT does not validate key/algorithm context. **Not exploitable:** WineBox uses only HS256 with a derived HMAC secret string, not JWK keys.
+  - **CVE-2026-48523** (Algorithm allow-list bypass with PyJWK/PyJWKClient) — The header `alg` is checked against the allow-list but the actual verification uses the algorithm bound to the PyJWK object. **Not exploitable:** WineBox does not use PyJWK or PyJWKClient; keys are plain HMAC secret strings.
+  - **CVE-2026-48525** (DoS via unbounded Base64URL decoding in `b64=false` detached JWS) — Arbitrarily large payload segments cause CPU/memory amplification before signature rejection. **Not exploitable:** WineBox uses standard compact JWTs, not detached JWS (`b64=false`).
+  - **CVE-2026-48522** (SSRF via PyJWKClient URI scheme) — PyJWKClient fetches any URI scheme without restriction. **Not exploitable:** WineBox does not use PyJWKClient.
+  - **CVE-2026-48524** (Unbounded JWKS endpoint requests) — PyJWKClient makes unbounded requests. **Not exploitable:** WineBox does not use PyJWKClient.
+- **Upgrade path:** Bump `pyjwt>=2.13.0` in pyproject.toml. No breaking changes expected.
+- **Recommendation:** Plan upgrade to 2.13.0 in a future maintenance cycle. None of the five vulnerabilities are exploitable in WineBox's current configuration, but upgrading removes the theoretical risk.
+- **Status:** Carried forward from 2026-06-08 review.
+
+**INFO-19: aiohttp 3.13.5 is affected by CVE-2026-47265 (cross-origin redirect cookie leak) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — aiohttp pinned at 3.13.5; patch is in aiohttp 3.14.0
+- **CVE:** CVE-2026-47265 — aiohttp re-attaches per-request cookies to redirected requests even when the redirect target is a different origin, allowing an attacker who controls the redirect target to receive cookies intended only for the original service. CVSS 6.6 (Medium).
+- **Impact on WineBox: None.** aiohttp is a transitive dependency (pulled in by the `anthropic` SDK). WineBox never imports or uses aiohttp directly — no `import aiohttp` or `from aiohttp` found anywhere in the codebase. The Anthropic SDK's usage of aiohttp does not pass per-request cookies.
+- **Upgrade path:** Bump aiohttp to >=3.14.0. This is a transitive dependency; updating may require waiting for the `anthropic` SDK to update its pin.
+- **Recommendation:** Monitor for an `anthropic` SDK release that pulls in aiohttp >=3.14.0. The vulnerability is not exploitable via WineBox's usage pattern.
+- **Status:** Carried forward from 2026-06-08 review.
+
+**INFO-20: urllib3 2.6.3 is affected by CVE-2026-44431 (header disclosure via ProxyManager) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — urllib3 pinned at 2.6.3; patch is in urllib3 2.7.0
+- **CVE:** CVE-2026-44431 — urllib3's `ProxyManager` discloses sensitive `Proxy-Authorization` headers on cross-origin redirects, allowing an attacker who controls the redirect target to capture proxy credentials.
+- **Impact on WineBox: None.** WineBox does not use `urllib3.ProxyManager` anywhere in the codebase. urllib3 is a transitive dependency (via `requests` and `botocore`), and WineBox's usage of these libraries does not involve proxy configuration.
+- **Upgrade path:** Bump urllib3 to >=2.7.0. Transitive dependency — updating `requests` or `botocore` should pull in the fix.
+- **Recommendation:** Plan upgrade in a future maintenance cycle. Not exploitable in WineBox.
+- **Status:** Carried forward from 2026-06-09 review.
+
+**INFO-21: aiohttp 3.13.5 is affected by CVE-2026-34993 (CookieJar deserialization) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — aiohttp pinned at 3.13.5; patch is in aiohttp 3.14.0
+- **CVE:** CVE-2026-34993 — Deserialization of untrusted data via `CookieJar.load()` can lead to arbitrary code execution when loading a cookie jar from an attacker-controlled file.
+- **Impact on WineBox: None.** WineBox does not use `aiohttp.CookieJar.load()` anywhere in the codebase. aiohttp is a transitive dependency (via the `anthropic` SDK), and the Anthropic SDK does not use `CookieJar.load()`.
+- **Upgrade path:** Same as INFO-19 — bump aiohttp to >=3.14.0 when a compatible `anthropic` SDK version is available.
+- **Recommendation:** Monitor for an `anthropic` SDK release that pulls in aiohttp >=3.14.0.
+- **Status:** Carried forward from 2026-06-09 review.
+
+**INFO-22: python-dotenv 1.2.1 is affected by CVE-2026-28684 (symlink file overwrite) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — python-dotenv pinned at 1.2.1; patch is in python-dotenv 1.2.2
+- **CVE:** CVE-2026-28684 — `set_key()` and `unset_key()` follow symlinks during a cross-device rename fallback, allowing local attackers to overwrite arbitrary files.
+- **Impact on WineBox: None.** WineBox does not call `set_key()` or `unset_key()` anywhere in the codebase. python-dotenv is a transitive dependency (via `pydantic-settings`) and is only used for `.env` file loading at startup via `dotenv_values()` / `load_dotenv()`, which are read-only operations not affected by this CVE.
+- **Upgrade path:** Bump python-dotenv to >=1.2.2 (transitive via pydantic-settings).
+- **Recommendation:** Plan upgrade in a future maintenance cycle. Not exploitable in WineBox.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-23: idna 3.11 is affected by CVE-2026-45409 (ReDoS) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — idna pinned at 3.11; patch is in idna 3.15
+- **CVE:** CVE-2026-45409 — Specially crafted inputs to `idna.encode()` bypass the CVE-2024-3651 fix and cause denial of service via regex backtracking.
+- **Impact on WineBox: None.** WineBox does not call `idna.encode()` directly. idna is a transitive dependency (via `requests`, `httpx`, `anyio`). User-supplied strings are never passed through IDNA encoding in WineBox's code — domain names are hardcoded or config-derived.
+- **Upgrade path:** Bump idna to >=3.15 (transitive dependency).
+- **Recommendation:** Plan upgrade in a future maintenance cycle. Not exploitable in WineBox.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-24: Admin panel `escapeHtml()` does not escape quote characters**
+
+- **File:** `winebox/admin/static/js/admin.js:56-61`
+- **Detail:** The admin panel's `escapeHtml()` function uses the `textContent`/`innerHTML` trick which only escapes `<`, `>`, and `&` — NOT `"` or `'`. At line 193, this is used in an attribute context: `data-user-email="${escapeHtml(user.email)}"`. If a user's email contained a `"` character, it could break out of the attribute. The main app's `escapeHtml()` in `app.js:3585-3596` correctly escapes all five characters using explicit replacement.
+- **Impact:** Very low — `EmailStr` validation prevents `"` in email addresses, and the admin panel is IP-restricted at the nginx layer. No practical exploitation path exists with current data types.
+- **Recommendation:** Update the admin panel's `escapeHtml()` to match the main app's implementation for defence-in-depth.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-25: MongoDB URL printed unmasked in two archived migration scripts**
+
+- **Files:**
+  - `scripts/migrations/migrate_sqlite_to_mongo.py:218` — `print(f"MongoDB URL: {mongodb_url}")` prints the full connection string including credentials
+  - `scripts/archive/migrate_wine_ownership.py:182` — `logger.info("Connecting to MongoDB at %s", settings.mongodb_url)` logs the full connection string at INFO level
+- **Detail:** Both scripts are archived one-time migration tools, not used in production operations. If re-run, they would leak MongoDB credentials (embedded in the `mongodb+srv://` URL) to stdout/logs. The main application code and deploy tooling properly mask connection strings (e.g., `deploy/common.py:547` masks to first/last 4 chars; `deploy/import_xwines_mongo.py:238` truncates to 30 chars).
+- **Impact:** Very low — archived scripts not used in normal operations.
+- **Recommendation:** Mask the URLs in both scripts (e.g., `mongodb_url[:30] + "..."`) for consistency with the rest of the codebase.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-26: python-multipart 0.0.28 is affected by CVE-2026-53539 (QuerystringParser DoS) — limited impact on WineBox**
+
+- **File:** `uv.lock` — python-multipart pinned at 0.0.28; patch is in python-multipart 0.0.30
+- **CVE:** CVE-2026-53539 — The `QuerystringParser` in python-multipart uses an inefficient algorithm to locate field separators in `application/x-www-form-urlencoded` POST data. When the body contains repeated semicolons, the parser exhibits O(B²) byte comparisons, causing CPU denial of service.
+- **Impact on WineBox: Limited.** The vulnerable parser is only invoked for endpoints that declare `Form()` parameters (record, met, checkout, scan, price capture). All form-accepting endpoints require `RequireAuth`, so an attacker must be authenticated. Additionally, nginx's `client_max_body_size 10M` caps the payload size, and the global rate limit (60/minute) provides baseline protection. However, a single well-crafted 10 MB form body with semicolons could still cause significant CPU load on a single worker.
+- **Upgrade path:** Bump `python-multipart>=0.0.30` in pyproject.toml. No breaking changes expected.
+- **Recommendation:** Upgrade to python-multipart >=0.0.30 in the next maintenance cycle. The risk is mitigated by authentication requirements and nginx body size limits, but the fix is straightforward.
+- **Status:** Carried forward from 2026-06-21 review.
+
+**INFO-27: pydantic-settings 2.12.0 is affected by CVE-2026-32690 (path traversal in NestedSecretsSettingsSource) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — pydantic-settings pinned at 2.12.0; patch is in pydantic-settings 2.14.2
+- **CVE:** CVE-2026-32690 (CVSS 5.9) — The `NestedSecretsSettingsSource` class in pydantic-settings has inconsistent symlink handling between its validation and loading phases. The `validate_secrets_path()` function does not descend into symlinked directories, making them invisible to the `secrets_dir_max_size` protection, but the `load_secrets()` loader follows symlinks via `glob.iglob()`, allowing an attacker with write access to `secrets_dir` to read arbitrary files.
+- **Impact on WineBox: None.** WineBox does not use `NestedSecretsSettingsSource` or any pydantic-settings secrets directory feature. The custom config loader (`winebox/config/loader.py`) loads configuration from TOML files and environment variables. No `secrets_dir`, `secrets_nested_subdir`, or `NestedSecretsSettingsSource` references exist anywhere in the codebase.
+- **Upgrade path:** Bump `pydantic-settings>=2.14.2` in pyproject.toml. Transitive dependency changes should be minimal.
+- **Recommendation:** Plan upgrade in a future maintenance cycle. Not exploitable in WineBox.
+- **Status:** Carried forward from 2026-06-21 review.
+
+**INFO-28: price-tracker.js has three unescaped values in HTML string construction**
+
+- **File:** `winebox/static/js/price-tracker.js`
+- **Locations:**
+  - Line 339: `c.photo_url` is inserted unescaped into an `<img src="...">` attribute. If a stored photo URL contained a `"` character, it could break out of the attribute and inject HTML.
+  - Line 346 (via `formatPrice` catch-path ~line 113): The `currency` value from the catch fallback in `formatPrice()` is concatenated without escaping. If a non-standard currency string containing HTML were sent via raw HTTP request (bypassing the select dropdown), it could be injected via `innerHTML`.
+  - Line 359: `c.id` is inserted unescaped into a `data-delete="..."` attribute.
+- **Impact: Very low.** All three values are server-generated: photo URLs are UUID-based paths constructed by the server, currency values originate from a select dropdown (though can be bypassed via raw requests), and IDs are MongoDB ObjectIds (hex-only strings). Additionally, the CSP (`script-src 'self'`) blocks inline script execution, including `onerror` event handlers, in modern browsers. The main app's `app.js:3585-3596` demonstrates the correct pattern with a proper 5-character `escapeHtml()`.
+- **Recommendation:** Use DOM APIs (`createElement`/`setAttribute`) for the photo URL, or upgrade price-tracker.js's `escapeHtml()` (line 366-369, which uses the weaker `textContent`/`innerHTML` trick missing quote escaping) to match the main app's implementation.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-29: Import processor broad `except Exception` returns `str(e)` to client**
+
+- **Files:**
+  - `winebox/services/import_service/processor.py:159-162` — `except Exception as e: error_msg = f"Row {row_index + 1}: {str(e)}"`
+  - `winebox/services/import_service/processor.py:268-274` — `except Exception as e: error_msg = f"Batch insert failed for rows {chunk.chunk_start + 1}-{chunk.chunk_end}: {str(e)}"`
+- **Detail:** Unlike INFO-2 which catches specific exception types with controlled messages, these catch generic `Exception` and include the raw `str(e)` in the `ImportResultResponse.errors` list returned to the client. If a MongoDB driver error, connection error, or other internal exception occurs during import processing, the raw exception message (which could contain collection names, server addresses, or internal details) would be sent to the authenticated user.
+- **Impact:** Low — requires authentication, and the error only surfaces during import processing (unusual flow). Most likely exception scenarios (validation errors, duplicate keys) produce benign messages. Infrastructure errors (connection failures) could leak server details but would also indicate an outage visible to the user anyway.
+- **Recommendation:** Catch specific expected exceptions and return a generic "Processing error on row N" message for unexpected exceptions. Log the full exception server-side for debugging.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-30: Custom field name dot injection in import remap creates nested MongoDB documents**
+
+- **File:** `winebox/services/import_service/batch_ops.py:176-178`
+- **Code:**
+  ```python
+  if field.startswith("custom:"):
+      custom_name = field[7:]
+      updates[f"custom_fields.{custom_name}"] = value
+  ```
+- **Detail:** The import remap endpoint allows users to map spreadsheet columns to custom fields. The custom field name is extracted from user input and used as a MongoDB dot-notation field path. A name like `custom:a.b.c` becomes `custom_fields.a.b.c`, creating an unintended nested document structure. The router-level validation only checks that the custom name is non-empty.
+- **Impact:** Very low — the nested documents are scoped entirely within the user's own `custom_fields` sub-document and cannot escape the `custom_fields` prefix. It creates confusing data structures within the user's own wine documents but poses no cross-user risk.
+- **Recommendation:** Reject custom field names containing `.`, `$`, or null bytes at the router level.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-31: Console email backends log full email body including verification/reset tokens at INFO level**
+
+- **Files:**
+  - `winebox/integrations/regstack_email.py:24-29` — `logger.info("EMAIL [%s -> %s] %s\n%s", ..., message.text)`
+  - `winebox/services/email/console.py:48-67` — `logger.info("\n...\nTo: %s\nSubject: %s\n...\n%s\n...", ..., text_content)`
+- **Detail:** Both console email backends (the regstack-adapter `WineboxConsoleEmailService` and the legacy `ConsoleEmailService`) log the full email text body at INFO level. This includes verification URLs containing tokens (e.g., `/#verify?token=<JWT>`) and password reset URLs containing tokens (e.g., `/#reset-password?token=<JWT>`). These tokens are time-limited but enable account takeover within their validity window.
+- **Impact:** Very low — the console backend is only used in development/testing (production uses SES). The risk exists only if the console backend is accidentally left active in production, or if OAT server logs are collected by an untrusted party.
+- **Recommendation:** Log only the subject and recipient at INFO level; log the body at DEBUG level (which is suppressed in standard configurations).
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-32: Price photo delete endpoint missing path traversal check before `unlink()`**
+
+- **File:** `winebox/routers/price_tracker.py:360`
+- **Code:**
+  ```python
+  photo_file = _photo_storage_path() / entry.photo_path
+  if photo_file.exists():
+      photo_file.unlink()
+  ```
+- **Detail:** When deleting a price entry's photo, the code constructs a file path from the database-stored `entry.photo_path` and calls `unlink()` without path traversal validation. In contrast, the `get_price_photo` endpoint (line 441) has explicit traversal checks (`/`, `\\`, `..`). The `ImageStorageService._safe_resolve()` method also has proper traversal protection; this delete path lacks the same defence-in-depth.
+- **Impact:** Very low — `photo_path` is always a UUID generated server-side (line 255) and is never user-controlled. An attacker would need to compromise the database to inject a malicious path. The ownership check before deletion provides an additional gate.
+- **Recommendation:** Add the same path traversal checks used in `get_price_photo` (reject `..`, `/`, `\` in the path component) for consistency.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-33: Admin `delete_user` uses wrong field to delete `raw_uploads` documents** *(NEW)*
+
+- **File:** `winebox/admin/routers/admin.py:317`
+- **Code:**
+  ```python
+  await raw_col.delete_many({"owner_id": user.id})
+  ```
+- **Detail:** The `RawUploadRow` model (collection `raw_uploads`) does not have an `owner_id` field — it uses `batch_id` to link back to an `ImportBatch`. This query silently matches zero documents, so raw upload rows are never actually cleaned up when an admin deletes a user. They become orphaned in the database. This is a functional bug, not a security vulnerability — the orphaned documents contain spreadsheet row data scoped by `batch_id` and cannot be accessed by other users.
+- **Impact:** None — orphaned data only. No data leak or cross-user access.
+- **Recommendation:** Fix the delete cascade to first collect the user's `ImportBatch` IDs, then delete `RawUploadRow` documents by `{"batch_id": {"$in": batch_ids}}`. Related to INFO-10 (missing `CellarEvent`/`CellarItem` cleanup in the same cascade).
+- **Status:** New finding in 2026-06-27 review.
+
+---
+
+### :green_circle: CLEAN (Passed review)
+
+#### 1. Dependency Vulnerability Check
+
+All key dependencies are at patched versions:
+
+| Package | Pin | Locked | Status |
+|---------|-----|--------|--------|
+| fastapi | >=0.109.0 | 0.128.1 | No direct 2026 CVEs (CVE-2026-2978/2979 affect fastapi-admin, not fastapi) |
+| uvicorn | >=0.27.0 | 0.40.0 | No known 2026 CVEs |
+| starlette | — | 0.50.0 | CVE-2026-48710 (BadHost) — no practical impact (see INFO-8) |
+| pydantic | >=2.0.0 | 2.12.5 | Clean (CVE-2026-25580/46678 affect pydantic-ai, not pydantic core) |
+| pymongo | >=4.10.0 | 4.16.0 | No known 2026 CVEs |
+| pillow | >=12.2.0 | 12.2.0 | Patched for CVE-2026-25990 + CVE-2026-40192 + CVE-2026-42308 |
+| python-multipart | >=0.0.26 | 0.0.28 | Patched for CVE-2026-40347 + CVE-2026-24486; CVE-2026-53539 limited impact (see INFO-26) |
+| jinja2 | >=3.1.6 | 3.1.6 | No known 2026 CVEs |
+| bcrypt | >=4.1.2 | 5.0.0 | Clean — no 2026 CVEs |
+| pyjwt | >=2.12.0 | 2.12.1 | Patched for CVE-2026-32597; five additional CVEs not exploitable (see INFO-18) |
+| cryptography | >=46.0.7 | 46.0.7 | Patched for CVE-2026-39892 + CVE-2026-34073 (see INFO-7 re version gap) |
+| anthropic | >=0.96.0 | 0.96.0 | Patched for CVE-2026-34450 + CVE-2026-34452; MCP CVEs not applicable |
+| slowapi | >=0.1.9 | 0.1.9 | No known 2026 CVEs |
+| openpyxl | >=3.1.0 | 3.1.5 | No known 2026 CVEs |
+| posthog | >=7.0.0 | 7.13.0 | No known 2026 CVEs |
+| cairosvg | >=2.9.0 | 2.9.0 | Patched for CVE-2026-31899 (see INFO-5 re unused) |
+| aiohttp | >=3.13.4 | 3.13.5 | Patched for CVE-2026-34520 + CVE-2026-34519 + CVE-2026-22815; CVE-2026-47265/34993 not exploitable (see INFO-19/21) |
+| urllib3 | — | 2.6.3 | CVE-2026-21441 patched; CVE-2026-44431 not exploitable (see INFO-20) |
+| requests | >=2.33.1 | 2.33.1 | Patched for CVE-2026-25645 |
+| certifi | >=2026.4.22 | 2026.4.22 | One CA bundle behind (2026.6.17 available); no security risk |
+| regstack | >=0.7.0 | 0.7.0 | No known CVEs |
+| httpx | — | 0.28.1 | No known 2026 CVEs |
+| fastapi-users | >=14.0.0 | 15.0.4 | No known 2026 CVEs |
+| python-dotenv | — | 1.2.1 | CVE-2026-28684 not exploitable (see INFO-22) |
+| idna | — | 3.11 | CVE-2026-45409 not exploitable (see INFO-23) |
+| pydantic-settings | — | 2.12.0 | CVE-2026-32690 not exploitable (see INFO-27) |
+
+No dependencies are yanked, compromised, or missing critical patches. No lockfile changes since last review (dependency versions identical). No supply chain concerns.
+
+#### 2. Hardcoded Secrets Scan
+
+- No API keys, connection strings, passwords, private keys, or JWTs found in source code.
+- `.gitignore` properly covers: `.env`, `secrets.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- `git ls-files` confirms no sensitive files tracked (only `config/secrets.env.example`).
+- Test fixtures use obvious dummy values (`sk-ant-api-key`, `phc_test_api_key`, `AKIAIOSFODNN7EXAMPLE`).
+- No secrets found in git history via `git log --diff-filter=A`.
+
+#### 3. Authentication & Authorization Audit
+
+All endpoints across main app, admin panel, and regstack auth audited (88 endpoints):
+
+- **All database queries** for user-owned data filter by `owner_id` or `cellar_id`.
+- Public endpoints (`/api/reference/*`, `/api/xwines/*`, `/health`, `/api/config/analytics`) serve only static reference data — no user information exposed.
+- Admin endpoints use `RequireAdmin` (not just `RequireAuth`).
+- Admin panel login rejects non-admin users with 403.
+- Self-modification prevention: admins cannot deactivate/delete/de-admin their own accounts.
+- Password changes invalidate all existing tokens via dual mechanism:
+  - Per-token blacklist (JTI-based)
+  - Bulk `tokens_invalidated_after` cutoff on user document
+- Constant-time password comparison via Argon2id `verify()` (pwdlib).
+- User registration validates email format (Pydantic `EmailStr`) and password length (8-128 chars).
+- JWT tokens use purpose-separated derived keys (session, password_reset, email_change) via HMAC-SHA256.
+- Anti-enumeration: forgot-password always returns the same message regardless of email existence.
+
+#### 4. NoSQL Injection & Query Safety
+
+- All regex searches use `re.escape()` before compilation (confirmed in `search_service.py`, `reference.py`, `xwines.py`, `xwines_enrichment.py`).
+- No unsafe MongoDB operators (`$where`, `$expr`, `$accumulator`, `$function`) found anywhere in application code.
+- All `ObjectId` parsing wrapped in `try/except InvalidId` with proper 400/404 responses.
+- All API inputs validated via Pydantic models — no raw `dict` or untyped JSON bodies.
+- `$in` arrays sourced from internal data (user IDs, wine IDs), never directly from unbounded user input.
+
+#### 5. Input Validation & Injection Prevention
+
+- File uploads validated: magic byte detection (main image storage + price captures), extension whitelist, size limits.
+- Path traversal prevented in image serving (`_safe_resolve()` rejects `..`, `/`, `\`; verifies resolved path stays inside storage directory).
+- Generated filenames use UUIDs, not user input.
+- Jinja2 email templates use `autoescape=True`.
+- No `eval()`, `exec()`, `__import__()`, or `compile()` in application code.
+- All paginated endpoints enforce maximum limits via `Query(ge=1, le=MAX_PAGE_SIZE)`.
+- Search query length capped at 200 characters.
+- Static site export uses `html.escape()` and custom `escapeHtml()` JS function.
+- XSS prevention consistent across all HTML rendering.
+
+#### 6. Rate Limiting & DoS Prevention
+
+- **Global:** 60 requests/minute per IP.
+- **Login:** 30/minute, 200/hour + account lockout after 5 failed attempts (15-minute window).
+- **Registration:** 10/minute, 50/hour.
+- **Password reset/change:** 5/minute, 20/hour.
+- **Search:** 120/minute, 2000/hour.
+- **Scan/enrichment:** 20/minute, 200/hour.
+- **X-Wines export:** 10/minute, 30/hour.
+- **Admin login:** 5/minute.
+- All paginated queries bounded by `MAX_USER_RESULTSET` (10,000) and `MAX_REFERENCE_RESULTSET` (5,000).
+- Database query timeouts configured: `serverSelectionTimeoutMS=5000`, `connectTimeoutMS=10000`, `socketTimeoutMS=30000`.
+- Upload size bounded by `max_upload_mb` config (default 10 MB) and nginx `client_max_body_size 10M`.
+
+#### 7. Session & Token Security
+
+- JWT tokens use HS256 with minimum 32-character secret key (enforced at startup).
+- Separate `WINEBOX_REGSTACK_JWT_SECRET` for regstack's purpose-derived keys.
+- Tokens include `jti` (UUID), `iat`, `exp`, `sub`, and `purpose` claims — all required on decode.
+- 2-hour token expiry.
+- Dual-layer revocation: per-token JTI blacklist + bulk user `tokens_invalidated_after` cutoff.
+- No token values logged anywhere in the codebase.
+- HSTS enabled in production.
+- Verification tokens hashed (SHA-256) in database, not stored raw.
+
+#### 8. Security Headers
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `X-XSS-Protection: 1; mode=block` (see INFO-14 for deprecation note)
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Content-Security-Policy`: `script-src 'self'` (no `unsafe-inline` for scripts), `frame-ancestors 'none'`, `object-src 'none'`.
+- CORS: empty origin list by default (same-origin only), explicit whitelist when configured.
+- API docs (`/docs`, `/redoc`, `/openapi.json`) disabled in production.
+- No inline `<script>` blocks in any served HTML template.
+- nginx: `server_tokens off`, TLSv1.2/1.3 only, strong cipher suite, session tickets off.
+
+#### 9. Data Exposure
+
+- `UserResponse` and `UserRead` models exclude `hashed_password` and internal fields.
+- Error messages are generic ("Invalid email or password") — no user enumeration.
+- Image serving endpoint returns uniform 404 for both "not found" and "not your image".
+- Admin `/info` endpoint intentionally omits MongoDB hostname.
+- Debug mode defaults to `False`; startup validation blocks production launch with debug enabled.
+- No stack traces, database connection strings, or file paths in error responses.
+- `owner_id` consistently stripped from API responses via Pydantic schema exclusion.
+
+#### 10. Git History Review
+
+- No code changes since last review. HEAD is at `262562b` (Security Review — 2026-06-26 — security-clean, previous review commit only).
+- No secret files accidentally committed (`git log --diff-filter=A` clean).
+- No force pushes, rebases, or reverts detected.
+
+#### 11. Infrastructure & Configuration
+
+- Production safety checks at startup: weak secret key blocked, localhost MongoDB warned, HTTPS enforcement checked.
+- Database safety check prevents non-production hosts from connecting to production MongoDB.
+- Secure defaults: `debug=False`, `cors_origins=[]` (same-origin), `email_verification_required=True`.
+- Admin panel IP-restricted in nginx with explicit allowlist (no empty sections allowed).
+- API docs disabled in production for both apps.
+- nginx: `server_tokens off`, TLSv1.2/1.3 only, session tickets off, HSTS, HTTP-to-HTTPS redirect.
+- Systemd services hardened with `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`.
+- MongoDB connection pool bounded: `minPoolSize=10`, `maxPoolSize=100`.
+
+#### 12. Third-Party Integration Security
+
+- Anthropic API key loaded from environment variables, not hardcoded. All calls have explicit timeouts (60-120 seconds).
+- PostHog API key loaded from secrets config. Analytics disabled by default. EU instance for GDPR compliance.
+- AWS credentials loaded from environment via named profile. Never logged.
+- No webhook endpoints that would require signature validation.
+- All external HTTP clients have explicit timeouts configured.
+- No SSRF vectors — no endpoint accepts user-supplied URLs for server-side fetching.
+
+---
+
+## :bar_chart: Summary
+
+| Severity | Count |
+|----------|-------|
+| :red_circle: CRITICAL | 0 |
+| :orange_circle: WARNING | 0 |
+| :yellow_circle: INFO | 33 |
+| :green_circle: CLEAN | 12 categories |
+
+**Date of review:** 2026-06-27
+**Reviewer:** Automated security audit (Claude Code)
+**Codebase version:** 0.7.86 (commit 262562b)
+
+### Comparison with Previous Review (2026-06-26)
+
+| Item | 2026-06-26 | 2026-06-27 | Status |
+|------|-----------|-----------|--------|
+| CRITICAL | 0 | 0 | Maintained |
+| WARNING | 0 | 0 | Maintained |
+| INFO | 32 | 33 | +1 new finding |
+
+### Changes Since Last Review
+
+- No application code changes since last review (HEAD at `262562b`, previous security review commit only).
+- All dependency versions unchanged.
+- 32 INFO findings carried forward unchanged.
+- 1 new INFO finding (INFO-33): Admin `delete_user` endpoint uses `owner_id` to delete `raw_uploads` documents, but `RawUploadRow` has no `owner_id` field (uses `batch_id`). The delete silently matches zero documents, leaving orphaned data. Functional bug with no security impact.
+- Full re-audit of all 12 categories confirms no regressions.
+
+### Top 3 Priorities
+
+1. **Plan coordinated FastAPI + Starlette upgrade (INFO-8)** — while CVE-2026-48710 is not exploitable in WineBox today, upgrading to FastAPI >=0.136.0 + Starlette >=1.0.1 removes the theoretical risk and keeps the stack current.
+2. **Bump PyJWT to >=2.13.0 (INFO-18)** — closes five CVEs (CVE-2026-48526, CVE-2026-48523, CVE-2026-48525, CVE-2026-48522, CVE-2026-48524) in a single upgrade. None are exploitable today, but the upgrade is straightforward and removes all theoretical risk.
+3. **Fix admin `delete_user` cascade (INFO-10 + INFO-33)** — the delete cascade is missing cleanup for `CellarEvent`, `CellarItem`, and `raw_uploads` documents. The `raw_uploads` cleanup also uses the wrong field (`owner_id` instead of `batch_id`), silently deleting nothing.


### PR DESCRIPTION
## Summary

Daily automated security audit — clean bill of health.

- **0 CRITICAL**, **0 WARNING**, **33 INFO** findings (32 carried forward + 1 new)
- No application code changes since last review (2026-06-26)
- All dependency versions unchanged
- Full re-audit of all 12 security categories confirms no regressions

### New Finding

- **INFO-33**: Admin `delete_user` uses wrong field (`owner_id`) to delete `raw_uploads` documents — `RawUploadRow` has no `owner_id` field (uses `batch_id`). The delete silently matches zero documents, leaving orphaned data. Functional bug with no security impact.

### Top 3 Priorities

1. Plan coordinated FastAPI + Starlette upgrade (INFO-8)
2. Bump PyJWT to >=2.13.0 (INFO-18)
3. Fix admin `delete_user` cascade (INFO-10 + INFO-33)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn3hqEL1sqXGd757aqPtfd)_