### PR TITLE
Security Review — 2026-07-08 — security-warning

### DIFF
--- a/docs/security-reports/2026-07-08.md
+++ b/docs/security-reports/2026-07-08.md
@@ -1,0 +1,592 @@
+# Security Review — 2026-07-08
+
+## Scope
+
+Comprehensive daily security audit of the WineBox project (FastAPI + MongoDB wine cellar application) covering:
+
+1. Dependency vulnerability check
+2. Hardcoded secrets scan
+3. Authentication & authorization audit
+4. NoSQL injection & query safety
+5. Input validation & injection prevention
+6. Rate limiting & DoS prevention
+7. Session & token security
+8. Security headers & CORS
+9. Data exposure review
+10. Git history review
+11. Infrastructure & configuration
+12. Third-party integration security
+
+**Notable context:** No application code changes since the last review (2026-07-06). HEAD is at `7d29a54` (version 0.7.86). Dependency versions unchanged in lockfile. All 37 INFO-level findings from the previous review carried forward. A deeper owner_id data isolation audit identified 3 new WARNING-level findings where secondary Wine lookups do not filter by `owner_id`. One new INFO finding added for newly disclosed Pillow CVEs.
+
+---
+
+## Findings
+
+### :red_circle: CRITICAL
+
+None.
+
+### :orange_circle: WARNING
+
+**WARN-1: Wine lookup without `owner_id` in export transactions endpoint**
+
+- **File:** `winebox/routers/export.py:250`
+- **Code:** `wines = await Wine.find({"_id": {"$in": wine_oids}}).to_list(length=MAX_USER_RESULTSET)`
+- **Detail:** The `export_transactions` endpoint fetches Wine documents by `_id` alone without an `owner_id` filter. The `wine_oids` are extracted from owner-scoped cellar events (correctly filtered by `owner_id`/`cellar_id`), but the Wine lookup itself could theoretically return wines belonging to another user if a data corruption or migration error placed a foreign `wine_id` in the user's cellar events.
+- **Impact:** Very low under normal operations — MongoDB ObjectIds are globally unique and cellar events are correctly owner-scoped. Requires data corruption to exploit. However, this violates the project's stated security policy that "ALL database queries for user data MUST filter by `owner_id`."
+- **Fix:** Add `"owner_id": current_user.id` to the query filter.
+
+**WARN-2: Bulk Wine lookup without `owner_id` in cellar_event_view**
+
+- **File:** `winebox/services/cellar_event_view.py:179`
+- **Code:** `wines = await Wine.find({"_id": {"$in": wine_ids}}).to_list()`
+- **Detail:** In `list_events_as_transactions`, the Wine lookup for decorating transaction responses with wine info has no `owner_id` constraint. This service backs the `GET /api/transactions` endpoint. Same risk profile as WARN-1.
+- **Fix:** Add `"owner_id": owner_id` to the query filter.
+
+**WARN-3: Single Wine lookup without `owner_id` in cellar_event_view**
+
+- **File:** `winebox/services/cellar_event_view.py:219`
+- **Code:** `w = await Wine.find_one({"_id": event.wine_id})`
+- **Detail:** In `get_event_as_transaction`, the single-wine fetch for the `GET /api/transactions/{id}` endpoint lacks `owner_id`. The event is verified as belonging to the user (line 210-212), but the subsequent Wine lookup is unscoped.
+- **Fix:** Add `"owner_id": owner_id` to the query filter.
+
+### :yellow_circle: INFO (Best practice recommendations)
+
+**INFO-1: CVE tracking comments missing for three dependencies**
+
+- **File:** `pyproject.toml`
+- **Detail:** Three dependencies have known CVEs that are already patched by the current version pins, but lack the tracking comments used elsewhere in the file:
+  - `cairosvg>=2.9.0` — CVE-2026-31899 (recursive `<use>` element DoS, CVSS 7.5)
+  - `anthropic>=0.96.0` — CVE-2026-34450 + CVE-2026-34452 (memory tool file permissions and TOCTOU, not used by WineBox)
+  - `python-multipart>=0.0.26` — CVE-2026-40347 (multipart preamble DoS)
+- **Impact:** No security risk — versions are already safe. Documentation consistency issue.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-2: Exception messages exposed in HTTP error details (4 locations)**
+
+- **Files:**
+  - `winebox/routers/import_router.py:180` — `detail=str(e)` for `ValueError`
+  - `winebox/routers/wines/record.py:152` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/met.py:157` — `detail=f"Invalid custom_fields JSON: {e}"` for `json.JSONDecodeError`
+  - `winebox/routers/wines/checkout.py:96` — `detail=str(e)` for `CellarDebitError`
+- **Detail:** All four catch specific exception types (not generic `Exception`), and the messages are user-facing parsing errors or domain-specific errors with controlled messages. No internal paths, database names, or stack traces are leaked.
+- **Impact:** Minimal — these are controlled error messages from known exception types.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-3: E2E test secret keys hardcoded in tasks.py**
+
+- **File:** `tasks.py` (lines 283, 2060)
+- **Values:** `"e2e-test-secret-key-not-for-production-use-1234567890"` and `"oat-e2e-test-secret-key-1234567890"`
+- **Detail:** Clearly labelled test-only values used for isolated E2E test environments. Not used in production. Low risk.
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-4: Password strength validation is length-only (8 characters minimum)**
+
+- **File:** regstack's `PasswordStr` type (min_length=8, max_length=128)
+- **Detail:** Registration and password change enforce a minimum of 8 characters but do not require complexity. This is acceptable per NIST SP 800-63B guidance (which discourages complexity rules).
+- **Status:** Carried forward from 2026-05-11 review.
+
+**INFO-5: `cairosvg` dependency appears unused**
+
+- **File:** `pyproject.toml` line 48
+- **Detail:** `cairosvg>=2.9.0` is declared as a dependency but is not imported anywhere in the codebase (`winebox/`, `scripts/`, `tests/`). Keeping an unused dependency increases attack surface without benefit.
+- **Recommendation:** Confirm whether CairoSVG is needed for a planned feature; if not, remove it from dependencies.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-6: nginx `client_max_body_size` is lower than the import upload app-level limit**
+
+- **Files:** `deploy/nginx-winebox.conf:191` (`client_max_body_size 10M`), `winebox/routers/import_router.py:143` (`MAX_IMPORT_BYTES = 25 MB`)
+- **Detail:** The application claims to accept spreadsheet imports up to 25 MB, but nginx rejects requests above 10 MB. Uploads between 10-25 MB will fail with a nginx 413 error before reaching the application.
+- **Impact:** No security risk — this is a functionality gap, not a vulnerability. The lower nginx limit is actually more conservative.
+- **Recommendation:** Either raise `client_max_body_size` to 25M or lower the application limit to match 10M.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-7: `cryptography` package is 3 major versions behind latest**
+
+- **File:** `uv.lock` — pinned at 46.0.7, latest is 49.0.0
+- **Detail:** All previously known CVEs (CVE-2026-39892, CVE-2026-34073, CVE-2026-26007) are patched at 46.0.7. The version gap itself is not a vulnerability, but staying current is advisable for defence in depth. See also INFO-33 for a new OpenSSL advisory.
+- **Recommendation:** Plan upgrade to 49.x in a future maintenance cycle.
+- **Status:** Carried forward from 2026-05-17 review.
+
+**INFO-8: Starlette 0.50.0 is affected by CVE-2026-48710 (BadHost) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — starlette pinned at 0.50.0; patch is in starlette 1.0.1
+- **CVE:** CVE-2026-48710 — Starlette reconstructs `request.url` from the HTTP Host header without validation. A malformed Host header can cause `request.url.path` to differ from the path the ASGI server actually routed, allowing middleware that makes security decisions based on `request.url.path` to be bypassed.
+- **Impact on WineBox: None.** WineBox does not use path-based auth middleware. Authentication is enforced via FastAPI dependency injection (`RequireAuth`, `RequireAdmin`) on individual route handlers, which operate on the ASGI scope path (the correctly-routed path), not `request.url.path`. Additionally, nginx normalises Host headers in production.
+- **Upgrade path:** FastAPI 0.128.1 constrains starlette to `<0.51.0,>=0.40.0`. Upgrading to starlette >=1.0.1 requires upgrading FastAPI to >=0.136.0. See also INFO-35 for additional Starlette CVEs.
+- **Recommendation:** Plan a coordinated FastAPI + Starlette upgrade in a future maintenance cycle.
+- **Status:** Carried forward from 2026-05-27 review.
+
+**INFO-9: Cascading delete in `delete_wine` does not scope by `owner_id`**
+
+- **File:** `winebox/routers/wines/crud.py:188-189`
+- **Detail:** When deleting a wine, the cascading deletion of `CellarEvent` and `Transaction` documents filters by `wine_id` but not by `owner_id`/`cellar_id`. The wine itself is already confirmed as owned by the current user via `get_wine_or_404` (line 177), and MongoDB ObjectIds are globally unique, so there is zero practical risk. However, adding `owner_id` to the cascade filter would be a defence-in-depth improvement.
+- **Impact:** None — the ownership check on the wine itself prevents any cross-user deletion.
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-10: Admin `delete_user` does not clean up `CellarEvent` or `CellarItem` documents**
+
+- **File:** `winebox/admin/routers/admin.py:303-330`
+- **Detail:** The admin delete-user endpoint removes wines, transactions, import batches, and raw uploads, but does not remove `CellarEvent` or `CellarItem` documents for the deleted user. This leaves orphaned data in the database. No security risk — the orphaned documents are scoped by `cellar_id`/`owner_id` and cannot be accessed by other users.
+- **Recommendation:** Add `CellarEvent` and `CellarItem` cleanup to the delete cascade.
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-11: Several Pydantic fields missing `max_length` constraints**
+
+- **Files:**
+  - `winebox/admin/routers/admin.py:193` — `CreateUserRequest.password` has no `max_length` (Argon2id will hash any length; behind `RequireAdmin`)
+  - `winebox/schemas/reference.py:189,206` — `WineScoreBase.notes` has no `max_length`
+  - `winebox/schemas/reference.py:186,203` — `WineScoreBase.score_type` has no `max_length` (mitigated by handler-level validation against `VALID_SCORE_TYPES`)
+  - `winebox/schemas/reference.py:173` — `WineGrapeBlendUpdate.grapes` list has no `max_length`
+  - `winebox/schemas/import_schemas.py:36` — `ColumnMappingRequest.mapping` dict has no size constraint (bounded by CSV header count elsewhere)
+  - `winebox/schemas/wine.py:63,66,69` — `WineUpdate.wine_type`, `price_tier`, `producer_type` have no `max_length`
+- **Detail:** These fields accept unbounded input at the Pydantic layer. All are behind `RequireAuth` or `RequireAdmin`, and most are bounded by application logic elsewhere. The global rate limit (60/min) and MongoDB socket timeout (30s) provide baseline protection.
+- **Impact:** Very low — attacker must be authenticated, and practical exploitation is limited by rate limiting and timeouts.
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-12: Vision-calling write endpoints rely on global rate limit only**
+
+- **Files:** `winebox/routers/wines/record.py`, `winebox/routers/wines/met.py`
+- **Detail:** The `POST /api/wines/record` and `POST /api/wines/met` endpoints can trigger Claude Vision API calls (expensive external service), but rely only on the global 60/minute rate limit rather than having their own tighter limits like the scan endpoint (20/minute). The `/api/wines/scan` endpoint has an explicit 20/minute limit for the same Vision functionality.
+- **Impact:** Low — an authenticated user could consume more Vision API quota than intended at 60 requests/minute vs the 20/minute cap on the equivalent scan endpoint.
+- **Recommendation:** Add explicit rate limits matching the scan endpoint (20/minute; 200/hour).
+- **Status:** Carried forward from 2026-05-28 review.
+
+**INFO-13: Admin deactivation does not bump `tokens_invalidated_after`**
+
+- **File:** `winebox/admin/routers/admin.py:265-272`
+- **Detail:** When an admin deactivates a user, the endpoint sets `is_active = False` but does not bump `tokens_invalidated_after`. This is not a bypass — regstack's auth dependency checks `user.is_active` on every authenticated request, so the deactivated user is effectively blocked immediately on their next request. However, bumping `tokens_invalidated_after` would add belt-and-suspenders redundancy.
+- **Impact:** None in current architecture — `is_active` check provides immediate blocking.
+- **Recommendation:** Consider setting `tokens_invalidated_after = now` alongside `is_active = False` for defence-in-depth.
+- **Status:** Carried forward from 2026-05-29 review.
+
+**INFO-14: Deprecated `X-XSS-Protection` header set to `1; mode=block`**
+
+- **File:** `winebox/main.py:46`
+- **Detail:** The `X-XSS-Protection` header is deprecated and has been removed from modern browsers. Setting it to `1; mode=block` could theoretically introduce XSS vulnerabilities in older browsers by enabling the browser's buggy XSS auditor. The strong Content-Security-Policy already provides comprehensive XSS protection.
+- **Impact:** Negligible — the strong CSP is the primary XSS defence.
+- **Recommendation:** Change to `X-XSS-Protection: 0` or remove the header.
+- **Status:** Carried forward from 2026-05-29 review.
+
+**INFO-15: Admin logout uses `RequireAuth` instead of `RequireAdmin`**
+
+- **File:** `winebox/admin/routers/auth.py:69-70`
+- **Detail:** The `/api/auth/logout` endpoint in the admin panel uses `RequireAuth` rather than `RequireAdmin`. This means a non-admin authenticated user who somehow obtains access to the admin panel (behind an IP allowlist at the nginx layer) could invoke the logout endpoint, which only revokes their own token — a self-destructive, non-escalating operation.
+- **Impact:** Negligible — the admin panel is IP-restricted, and logout only affects the caller's own session.
+- **Recommendation:** Change to `RequireAdmin` for consistency.
+- **Status:** Carried forward from 2026-05-29 review.
+
+**INFO-16: Four `to_list()` calls lack explicit length bounds**
+
+- **Files:**
+  - `winebox/services/cellar_event_view.py:242` — `list_wine_transactions()` calls `.to_list()` with no length limit.
+  - `winebox/routers/bottles.py:190` — `get_item_events()` calls `CellarEvent.find(...).sort(...).to_list()` with no length limit.
+  - `winebox/services/cellar_inventory.py:88` — `cursor.to_list(length=None)` for cellar items.
+  - `winebox/services/cellar_debit.py:142` — `.to_list(length=None)` for cellar items matching a wine.
+- **Detail:** All queries are scoped to a single wine/item/user and naturally produce small result sets. However, adding `length=MAX_USER_RESULTSET` would provide defence-in-depth.
+- **Impact:** Very low — result sets are naturally small due to scoping.
+- **Recommendation:** Add explicit `length=MAX_USER_RESULTSET` to all four calls.
+- **Status:** Carried forward from 2026-05-31 review.
+
+**INFO-17: nginx configs lack OCSP stapling directives**
+
+- **Files:** `deploy/nginx-winebox.conf`, `deploy/nginx-winebox-oat.conf`
+- **Detail:** Neither production nor OAT nginx configs include `ssl_stapling on;`, `ssl_stapling_verify on;`, or `ssl_stapling_resolver` directives.
+- **Impact:** Low — browsers fall back to direct OCSP checks or soft-fail. Performance and privacy improvement only.
+- **Recommendation:** Add `ssl_stapling on; ssl_stapling_verify on; resolver 1.1.1.1 8.8.8.8 valid=300s;` to both nginx TLS server blocks.
+- **Status:** Carried forward from 2026-06-04 review.
+
+**INFO-18: PyJWT 2.12.1 is affected by five CVEs — none exploitable in WineBox**
+
+- **File:** `uv.lock` — pyjwt pinned at 2.12.1; all five are patched in pyjwt 2.13.0
+- **CVEs affecting PyJWT 2.12.1:**
+  - **CVE-2026-48526** (Algorithm confusion) — Not exploitable: WineBox uses only HS256 with a derived HMAC secret string, not JWK keys.
+  - **CVE-2026-48523** (Algorithm allow-list bypass with PyJWK/PyJWKClient) — Not exploitable: WineBox does not use PyJWK or PyJWKClient.
+  - **CVE-2026-48525** (DoS via unbounded Base64URL decoding in `b64=false` detached JWS) — Not exploitable: WineBox uses standard compact JWTs, not detached JWS.
+  - **CVE-2026-48522** (SSRF via PyJWKClient URI scheme) — Not exploitable: WineBox does not use PyJWKClient.
+  - **CVE-2026-48524** (Unbounded JWKS endpoint requests) — Not exploitable: WineBox does not use PyJWKClient.
+- **Upgrade path:** Bump `pyjwt>=2.13.0` in pyproject.toml. No breaking changes expected.
+- **Recommendation:** Upgrade to 2.13.0 in next maintenance cycle. None of the five CVEs are exploitable today, but the upgrade is straightforward.
+- **Status:** Carried forward from 2026-06-08 review.
+
+**INFO-19: aiohttp 3.13.5 is affected by CVE-2026-47265 (cross-origin redirect cookie leak) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — aiohttp pinned at 3.13.5; patch is in aiohttp 3.14.0
+- **CVE:** CVE-2026-47265 — aiohttp re-attaches per-request cookies to redirected requests even when the redirect target is a different origin.
+- **Impact on WineBox: None.** aiohttp is a transitive dependency (via the `anthropic` SDK). WineBox never imports or uses aiohttp directly. See also INFO-36 for nine additional aiohttp CVEs.
+- **Recommendation:** Monitor for an `anthropic` SDK release that pulls in aiohttp >=3.14.1.
+- **Status:** Carried forward from 2026-06-08 review.
+
+**INFO-20: urllib3 2.6.3 is affected by CVE-2026-44431 (header disclosure via ProxyManager) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — urllib3 pinned at 2.6.3; patch is in urllib3 2.7.0
+- **CVE:** CVE-2026-44431 — urllib3's `ProxyManager` discloses sensitive `Proxy-Authorization` headers on cross-origin redirects.
+- **Impact on WineBox: None.** WineBox does not use `urllib3.ProxyManager`. See also INFO-37 for an additional urllib3 CVE.
+- **Recommendation:** Plan upgrade in a future maintenance cycle.
+- **Status:** Carried forward from 2026-06-09 review.
+
+**INFO-21: aiohttp 3.13.5 is affected by CVE-2026-34993 (CookieJar deserialization) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — aiohttp pinned at 3.13.5; patch is in aiohttp 3.14.0
+- **CVE:** CVE-2026-34993 — Deserialization of untrusted data via `CookieJar.load()` can lead to arbitrary code execution.
+- **Impact on WineBox: None.** WineBox does not use `aiohttp.CookieJar.load()`.
+- **Recommendation:** Same as INFO-19.
+- **Status:** Carried forward from 2026-06-09 review.
+
+**INFO-22: python-dotenv 1.2.1 is affected by CVE-2026-28684 (symlink file overwrite) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — python-dotenv pinned at 1.2.1; patch is in python-dotenv 1.2.2
+- **CVE:** CVE-2026-28684 — `set_key()` and `unset_key()` follow symlinks during a cross-device rename fallback.
+- **Impact on WineBox: None.** WineBox does not call `set_key()` or `unset_key()`. python-dotenv is only used for read-only `.env` file loading.
+- **Recommendation:** Plan upgrade in a future maintenance cycle.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-23: idna 3.11 is affected by CVE-2026-45409 (ReDoS) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — idna pinned at 3.11; patch is in idna 3.15
+- **CVE:** CVE-2026-45409 — Specially crafted inputs to `idna.encode()` cause denial of service via regex backtracking.
+- **Impact on WineBox: None.** WineBox does not call `idna.encode()` directly. idna is a transitive dependency. User-supplied strings are never passed through IDNA encoding.
+- **Recommendation:** Plan upgrade in a future maintenance cycle.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-24: Admin panel `escapeHtml()` does not escape quote characters**
+
+- **File:** `winebox/admin/static/js/admin.js:56-61`
+- **Detail:** The admin panel's `escapeHtml()` function only escapes `<`, `>`, and `&` — not `"` or `'`. At line 193, this is used in an attribute context: `data-user-email="${escapeHtml(user.email)}"`. The main app's `escapeHtml()` in `app.js:3585-3596` correctly escapes all five characters.
+- **Impact:** Very low — `EmailStr` validation prevents `"` in email addresses, and the admin panel is IP-restricted.
+- **Recommendation:** Update the admin panel's `escapeHtml()` to match the main app's implementation.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-25: MongoDB URL printed unmasked in two archived migration scripts**
+
+- **Files:**
+  - `scripts/migrations/migrate_sqlite_to_mongo.py:218` — `print(f"MongoDB URL: {mongodb_url}")`
+  - `scripts/archive/migrate_wine_ownership.py:182` — `logger.info("Connecting to MongoDB at %s", settings.mongodb_url)`
+- **Detail:** Both scripts are archived one-time migration tools, not used in production operations.
+- **Recommendation:** Mask the URLs for consistency with the rest of the codebase.
+- **Status:** Carried forward from 2026-06-15 review.
+
+**INFO-26: python-multipart 0.0.28 is affected by CVE-2026-53539 (QuerystringParser DoS) — limited impact on WineBox**
+
+- **File:** `uv.lock` — python-multipart pinned at 0.0.28; patch is in python-multipart 0.0.30
+- **CVE:** CVE-2026-53539 — The `QuerystringParser` uses an inefficient algorithm to locate field separators in `application/x-www-form-urlencoded` POST data, exhibiting O(B^2) byte comparisons with repeated semicolons.
+- **Impact on WineBox: Limited.** Vulnerable parser is only invoked for endpoints with `Form()` parameters. All form endpoints require `RequireAuth`, and nginx caps payload at 10 MB. See also INFO-34 for two additional python-multipart CVEs.
+- **Recommendation:** Upgrade to python-multipart >=0.0.31 in the next maintenance cycle.
+- **Status:** Carried forward from 2026-06-21 review.
+
+**INFO-27: pydantic-settings 2.12.0 is affected by CVE-2026-32690 (path traversal in NestedSecretsSettingsSource) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — pydantic-settings pinned at 2.12.0; patch is in pydantic-settings 2.14.2
+- **CVE:** CVE-2026-32690 (CVSS 5.9) — The `NestedSecretsSettingsSource` class has inconsistent symlink handling between validation and loading phases.
+- **Impact on WineBox: None.** WineBox does not use `NestedSecretsSettingsSource` or any pydantic-settings secrets directory feature.
+- **Recommendation:** Plan upgrade in a future maintenance cycle.
+- **Status:** Carried forward from 2026-06-21 review.
+
+**INFO-28: price-tracker.js has three unescaped values in HTML string construction**
+
+- **File:** `winebox/static/js/price-tracker.js`
+- **Locations:** Line 339 (`c.photo_url` unescaped in `<img src>`), line 346 (`currency` fallback unescaped), line 359 (`c.id` unescaped in `data-delete` attribute).
+- **Impact: Very low.** All values are server-generated (UUID paths, MongoDB ObjectIds). CSP blocks inline script execution. The main app's `app.js:3585-3596` demonstrates the correct 5-character `escapeHtml()` pattern.
+- **Recommendation:** Use DOM APIs or upgrade price-tracker.js's `escapeHtml()` to match the main app's implementation.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-29: Import processor broad `except Exception` returns `str(e)` to client**
+
+- **Files:**
+  - `winebox/services/import_service/processor.py:159-162` — `except Exception as e: error_msg = f"Row {row_index + 1}: {str(e)}"`
+  - `winebox/services/import_service/processor.py:268-274` — `except Exception as e: error_msg = f"Batch insert failed for rows ..."`
+- **Detail:** These catch generic `Exception` and include the raw `str(e)` in the `ImportResultResponse.errors` list returned to the client. If a MongoDB driver error occurs during import processing, internal details (collection names, server addresses) could be exposed.
+- **Impact:** Low — requires authentication and only surfaces during import processing.
+- **Recommendation:** Catch specific expected exceptions and return generic messages for unexpected ones. Log full exceptions server-side.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-30: Custom field name dot injection in import remap creates nested MongoDB documents**
+
+- **File:** `winebox/services/import_service/batch_ops.py:176-178`
+- **Detail:** A custom field name like `custom:a.b.c` becomes `custom_fields.a.b.c`, creating an unintended nested document structure. Scoped entirely within the user's own `custom_fields` sub-document.
+- **Impact:** Very low — no cross-user risk.
+- **Recommendation:** Reject custom field names containing `.`, `$`, or null bytes at the router level.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-31: Console email backends log full email body including verification/reset tokens at INFO level**
+
+- **Files:**
+  - `winebox/integrations/regstack_email.py:24-29` — `logger.info("EMAIL [%s -> %s] %s\n%s", ..., message.text)`
+  - `winebox/services/email/console.py:48-67` — `logger.info("\n...\nTo: %s\nSubject: %s\n...\n%s\n...", ..., text_content)`
+- **Detail:** Console email backends log verification and password reset URLs containing tokens. Only used in development (production uses SES).
+- **Impact:** Very low — dev-only risk.
+- **Recommendation:** Log body at DEBUG level, not INFO.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-32: Price photo delete endpoint missing path traversal check before `unlink()`**
+
+- **File:** `winebox/routers/price_tracker.py:360`
+- **Detail:** The delete path lacks the traversal checks (`/`, `\\`, `..`) used in `get_price_photo`. The `photo_path` is always a server-generated UUID, so no practical risk exists.
+- **Recommendation:** Add the same path traversal checks used in `get_price_photo` for consistency.
+- **Status:** Carried forward from 2026-06-22 review.
+
+**INFO-33: cryptography 46.0.7 is affected by GHSA-537c-gmf6-5ccf (OpenSSL vulnerability in bundled copy)**
+
+- **File:** `uv.lock` — cryptography pinned at 46.0.7; fix is in cryptography 48.0.1
+- **Advisory:** GHSA-537c-gmf6-5ccf — The statically linked OpenSSL copy in cryptography 46.0.7 contains a known vulnerability. Details at https://openssl-library.org/news/secadv/20260609.txt.
+- **Impact on WineBox: Unclear without full OpenSSL advisory details.** cryptography is used transitively for TLS and JWT operations. The bundled OpenSSL vulnerability may or may not be reachable via WineBox's usage patterns.
+- **Upgrade path:** Bump cryptography to >=48.0.1. This is a 2-major-version jump (46 to 48) and may require testing for compatibility.
+- **Recommendation:** Prioritize this upgrade alongside the existing INFO-7 version gap recommendation. The OpenSSL advisory adds urgency beyond the version-gap concern.
+- **Status:** Carried forward from 2026-07-06 review.
+
+**INFO-34: python-multipart 0.0.28 is affected by two additional CVEs (CVE-2026-53540, CVE-2026-53538)**
+
+- **File:** `uv.lock` — python-multipart pinned at 0.0.28; fixes in python-multipart 0.0.31
+- **CVEs:**
+  - **CVE-2026-53540** (Negative Content-Length) — A negative `Content-Length` header turns the bounded multipart read into an unbounded read, enabling memory exhaustion / DoS. **Limited impact on WineBox:** nginx likely rejects negative `Content-Length` before it reaches the application, and all form endpoints require `RequireAuth`. Global rate limit provides baseline protection.
+  - **CVE-2026-53538** (Semicolon as field separator) — Semicolons are treated as field separators in urlencoded bodies contrary to the WHATWG spec, potentially causing parameter injection/confusion. **Limited impact on WineBox:** form endpoints use typed `Form()` parameters with Pydantic validation, limiting the scope of parameter confusion.
+- **Upgrade path:** Bump `python-multipart>=0.0.31` (same as INFO-26 recommendation).
+- **Recommendation:** These two CVEs add urgency to the python-multipart upgrade already recommended in INFO-26. All three CVEs are fixed in 0.0.31.
+- **Status:** Carried forward from 2026-07-06 review.
+
+**INFO-35: Starlette 0.50.0 is affected by three additional CVEs (CVE-2026-54282, CVE-2026-54283, CVE-2026-48817)**
+
+- **File:** `uv.lock` — starlette pinned at 0.50.0; fixes in starlette >=1.3.1
+- **CVEs:**
+  - **CVE-2026-54282** (Path without leading "/" shifts authority boundary) — An attacker can manipulate `request.url.hostname` via a path without a leading slash. **Not exploitable in WineBox:** same mitigation as CVE-2026-48710 (INFO-8) — auth uses dependency injection, not `request.url`.
+  - **CVE-2026-54283** (max_fields/max_part_size silently ignored for urlencoded) — Resource exhaustion via large urlencoded bodies bypassing size limits. **Limited impact on WineBox:** nginx `client_max_body_size 10M` provides upstream protection, and all form endpoints require authentication.
+  - **CVE-2026-48817** (HTTPEndpoint method dispatch to arbitrary attributes) — Non-standard HTTP method names can dispatch to arbitrary class attributes. **Not exploitable in WineBox:** WineBox uses function-based route handlers, not `HTTPEndpoint` subclasses.
+  - Note: CVE-2026-48818 (Windows UNC path SSRF in StaticFiles) was also identified but is not applicable — WineBox runs on Linux.
+- **Upgrade path:** Same as INFO-8 — requires upgrading FastAPI from 0.128.1 to >=0.135.0 to unblock starlette >=1.3.1.
+- **Recommendation:** These three CVEs add urgency to the coordinated FastAPI + Starlette upgrade already recommended in INFO-8.
+- **Status:** Carried forward from 2026-07-06 review.
+
+**INFO-36: aiohttp 3.13.5 is affected by nine additional CVEs — no practical impact on WineBox**
+
+- **File:** `uv.lock` — aiohttp pinned at 3.13.5; fixes in aiohttp 3.14.1
+- **CVEs (in addition to CVE-2026-47265 in INFO-19 and CVE-2026-34993 in INFO-21):**
+  - CVE-2026-54277 — `max_line_size` bypass in C parser (DoS via memory exhaustion)
+  - CVE-2026-54273 — Unlimited pipelined request queuing (DoS)
+  - CVE-2026-54274 — Oversized incomplete websocket frames bypass size limits (DoS)
+  - CVE-2026-54278 — Compressed body decompressed into memory in one chunk (zip bomb)
+  - CVE-2026-50269 — Header injection via multipart/payload headers
+  - CVE-2026-54275 — TLS SNI check bypass on connection reuse
+  - CVE-2026-54276 — DigestAuth credential leak after cross-origin redirect
+  - CVE-2026-54279 — Host-only cookies lose host-only status after save/load
+  - CVE-2026-54280 — Resource leak on client disconnect during write
+- **Impact on WineBox: None.** aiohttp is a transitive dependency pulled in by the `anthropic` SDK. WineBox never imports or uses aiohttp directly. The Anthropic SDK's usage pattern does not exercise any of the vulnerable code paths (no CookieJar, no pipelined requests, no websockets, no DigestAuth, no custom C parser settings).
+- **Upgrade path:** Bump aiohttp to >=3.14.1 when a compatible `anthropic` SDK version is available.
+- **Recommendation:** The cumulative count of 11 CVEs in aiohttp 3.13.5 (INFO-19 + INFO-21 + these nine) strengthens the case for a coordinated aiohttp upgrade. Monitor for an `anthropic` SDK release that bumps the aiohttp floor.
+- **Status:** Carried forward from 2026-07-06 review.
+
+**INFO-37: urllib3 2.6.3 is affected by CVE-2026-44432 (decompression bomb) — no practical impact on WineBox**
+
+- **File:** `uv.lock` — urllib3 pinned at 2.6.3; fix is in urllib3 2.7.0
+- **CVE:** CVE-2026-44432 — Brotli streaming and `drain_conn()` can decompress entire response into memory, enabling decompression bomb attacks.
+- **Impact on WineBox: None.** WineBox does not decompress arbitrary external responses. urllib3 is used transitively (via `requests` and `botocore`) for well-known endpoints (S3, PyPI).
+- **Upgrade path:** Bump urllib3 to >=2.7.0 (transitive via `requests` or `botocore`).
+- **Recommendation:** Plan upgrade alongside INFO-20.
+- **Status:** Carried forward from 2026-07-06 review.
+
+**INFO-38: Pillow 12.2.0 is affected by three new CVEs (CVE-2026-55379, CVE-2026-55380, CVE-2026-55798) — no practical impact on WineBox** :new:
+
+- **File:** `uv.lock` — pillow pinned at 12.2.0; fixes in pillow 12.3.0
+- **CVEs:**
+  - **CVE-2026-55379** (BDF font memory allocation DoS) — `BdfFontFile.bdf_char()` reads attacker-controlled width/height from a BDF font file and passes them to `Image.new()` without calling `_decompression_bomb_check()`. **Not exploitable in WineBox:** WineBox processes JPEG/PNG wine label images, not BDF font files.
+  - **CVE-2026-55380** (GD 2.x image memory allocation DoS) — `GdImageFile._open()` reads dimensions from a GD 2.x file header without size checks, allowing a ~1 KB file to trigger ~4.3 GB of C-heap allocation. **Not exploitable in WineBox:** WineBox validates file types via magic bytes and only accepts JPEG/PNG/HEIC/WEBP, not GD 2.x format files.
+  - **CVE-2026-55798** (Windows-only command injection via ImageShow) — `WindowsViewer.get_command()` does not escape file paths before passing to `subprocess.Popen` with `shell=True`. **Not applicable:** WineBox runs on Linux and does not use `Image.show()`.
+- **Upgrade path:** Bump `pillow>=12.3.0` in pyproject.toml.
+- **Recommendation:** Upgrade to 12.3.0 in next maintenance cycle. None of the three CVEs are exploitable via WineBox's file handling, but the upgrade is straightforward.
+- **Status:** New in 2026-07-08 review.
+
+**INFO-39: Six `update_one` calls do not re-assert `owner_id`/`cellar_id` in the filter** :new:
+
+- **Files:**
+  - `winebox/routers/bottles.py:44-46` — `wines_col.update_one({"_id": wine.id}, ...)` after verified ownership
+  - `winebox/routers/bottles.py:139-141` — `cellar_col.update_one({"_id": oid}, ...)` after verified ownership at line 117
+  - `winebox/routers/cases.py:149-151` — `wines_col.update_one({"_id": wine.id}, ...)` after verified ownership
+  - `winebox/routers/cases.py:291-293` — `cellar_col.update_one({"_id": oid}, ...)` after verified ownership at line 258
+  - `winebox/services/cellar_debit.py:180-183` — `cellar_col.update_one({"_id": item["_id"]}, ...)` after owner-scoped fetch at line 118
+  - `winebox/services/demo_service.py:393-396` — `wines_col.update_one({"_id": wine_id}, ...)` for wine created by same function
+- **Detail:** In all six cases, the document was verified as owned by the current user in a preceding read, but the subsequent `update_one` does not re-assert ownership in its filter. Under normal operation these are safe (MongoDB `_id` is globally unique and the ownership was just verified), but the pattern violates defence-in-depth against TOCTOU races or future refactors.
+- **Impact:** None under normal operation. Defence-in-depth improvement only.
+- **Recommendation:** Add `"owner_id": current_user.id` or `"cellar_id": current_user.id` to each update filter.
+- **Status:** New in 2026-07-08 review.
+
+---
+
+### :green_circle: CLEAN (Passed review)
+
+#### 1. Dependency Vulnerability Check
+
+All key dependencies are at patched versions for their known direct CVEs:
+
+| Package | Pin | Locked | Status |
+|---------|-----|--------|--------|
+| fastapi | >=0.109.0 | 0.128.1 | No direct 2026 CVEs |
+| uvicorn | >=0.27.0 | 0.40.0 | No known 2026 CVEs |
+| starlette | — | 0.50.0 | CVE-2026-48710 + 3 more CVEs — no practical impact (see INFO-8, INFO-35) |
+| pydantic | >=2.0.0 | 2.12.5 | Clean |
+| pymongo | >=4.10.0 | 4.16.0 | No known 2026 CVEs |
+| pillow | >=12.2.0 | 12.2.0 | Patched for CVE-2026-25990 + CVE-2026-40192 + CVE-2026-42308; 3 new CVEs not exploitable (see INFO-38) |
+| python-multipart | >=0.0.26 | 0.0.28 | Patched for CVE-2026-40347; 3 additional CVEs limited impact (see INFO-26, INFO-34) |
+| jinja2 | >=3.1.6 | 3.1.6 | No known 2026 CVEs |
+| bcrypt | >=4.1.2 | 5.0.0 | Clean |
+| pyjwt | >=2.12.0 | 2.12.1 | 5 CVEs not exploitable (see INFO-18) |
+| cryptography | >=46.0.7 | 46.0.7 | OpenSSL advisory (see INFO-33) |
+| anthropic | >=0.96.0 | 0.96.0 | Patched for CVE-2026-34450 + CVE-2026-34452 |
+| slowapi | >=0.1.9 | 0.1.9 | No known 2026 CVEs |
+| openpyxl | >=3.1.0 | 3.1.5 | No known 2026 CVEs |
+| posthog | >=7.0.0 | 7.13.0 | No known 2026 CVEs |
+| cairosvg | >=2.9.0 | 2.9.0 | Patched for CVE-2026-31899 |
+| aiohttp | >=3.13.4 | 3.13.5 | 11 CVEs not exploitable via WineBox (see INFO-19, 21, 36) |
+| urllib3 | — | 2.6.3 | 2 CVEs not exploitable via WineBox (see INFO-20, 37) |
+| requests | >=2.33.1 | 2.33.1 | Patched for CVE-2026-25645 |
+| certifi | >=2026.4.22 | 2026.4.22 | One CA bundle behind; no security risk |
+| regstack | >=0.7.0 | 0.7.0 | No known CVEs |
+| httpx | — | 0.28.1 | No known 2026 CVEs |
+| pydantic-settings | — | 2.12.0 | CVE-2026-32690 not exploitable (see INFO-27) |
+| python-dotenv | — | 1.2.1 | CVE-2026-28684 not exploitable (see INFO-22) |
+| idna | — | 3.11 | CVE-2026-45409 not exploitable (see INFO-23) |
+
+No dependencies are yanked, compromised, or missing critical patches. No supply chain concerns.
+
+#### 2. Hardcoded Secrets Scan
+
+- No API keys, connection strings, passwords, private keys, or JWTs found in source code.
+- `.gitignore` properly covers: `.env`, `secrets.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- `git ls-files` confirms no sensitive files tracked (only `config/secrets.env.example`).
+- Test fixtures use obvious dummy values (`sk-ant-api-key`, `phc_test_api_key`, `AKIAIOSFODNN7EXAMPLE`).
+- No secrets found in git history via `git log --diff-filter=A`.
+
+#### 3. Authentication & Authorization Audit
+
+All endpoints across main app, admin panel, and regstack auth audited (106+ endpoints):
+
+- **All database queries** for user-owned data filter by `owner_id` or `cellar_id` at the primary lookup level. Three secondary lookups identified as WARN-1/2/3.
+- Public endpoints (`/api/reference/*`, `/api/xwines/*`, `/health`, `/api/config/analytics`) serve only static reference data.
+- Admin endpoints use `RequireAdmin` (not just `RequireAuth`).
+- Admin panel login rejects non-admin users with 403.
+- Self-modification prevention: admins cannot deactivate/delete/de-admin their own accounts.
+- Password changes invalidate all existing tokens via dual mechanism (per-token blacklist + bulk `tokens_invalidated_after` cutoff).
+- Constant-time password comparison via Argon2id `verify()` (pwdlib).
+- JWT tokens use purpose-separated derived keys via HMAC-SHA256.
+- Anti-enumeration: forgot-password always returns the same message regardless of email existence.
+
+#### 4. NoSQL Injection & Query Safety
+
+- All regex searches use `re.escape()` before compilation.
+- No unsafe MongoDB operators (`$where`, `$expr`, `$accumulator`, `$function`) found.
+- All `ObjectId` parsing wrapped in `try/except InvalidId`.
+- All API inputs validated via Pydantic models — no raw `dict` or untyped JSON bodies.
+- `$in` arrays sourced from internal data, never directly from unbounded user input.
+
+#### 5. Input Validation & Injection Prevention
+
+- File uploads validated: magic byte detection, extension whitelist, size limits.
+- Path traversal prevented in image serving (`_safe_resolve()` rejects `..`, `/`, `\`).
+- Generated filenames use UUIDs, not user input.
+- Jinja2 email templates use `autoescape=True`.
+- No `eval()`, `exec()`, `__import__()`, or `compile()` in application code.
+- All paginated endpoints enforce maximum limits.
+- Search query length capped at 200 characters.
+
+#### 6. Rate Limiting & DoS Prevention
+
+- **Global:** 60 requests/minute per IP.
+- **Login:** 30/minute, 200/hour + account lockout after 5 failed attempts.
+- **Registration:** 10/minute, 50/hour.
+- **Password reset/change:** 5/minute, 20/hour.
+- **Search:** 120/minute, 2000/hour.
+- **Scan/enrichment:** 20/minute, 200/hour.
+- **Admin login:** 5/minute.
+- All paginated queries bounded by `MAX_USER_RESULTSET` (10,000) and `MAX_REFERENCE_RESULTSET` (5,000).
+- Database query timeouts configured.
+- Upload size bounded by config and nginx.
+
+#### 7. Session & Token Security
+
+- JWT tokens use HS256 with minimum 32-character secret key (enforced at startup).
+- Separate purpose-derived keys for session, password_reset, email_change.
+- Tokens include `jti` (UUID), `iat`, `exp`, `sub`, and `purpose` claims.
+- 2-hour token expiry.
+- Dual-layer revocation: per-token JTI blacklist + bulk user `tokens_invalidated_after` cutoff.
+- No token values logged anywhere.
+- HSTS enabled in production.
+
+#### 8. Security Headers
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Content-Security-Policy`: `script-src 'self'` (no `unsafe-inline` for scripts), `frame-ancestors 'none'`, `object-src 'none'`.
+- CORS: empty origin list by default (same-origin only).
+- API docs disabled in production.
+- No inline `<script>` blocks.
+- nginx: `server_tokens off`, TLSv1.2/1.3 only, strong cipher suite, session tickets off.
+
+#### 9. Data Exposure
+
+- `hashed_password` never exposed in any API response.
+- Error messages are generic — no user enumeration.
+- Image serving returns uniform 404 for both "not found" and "not your image".
+- Admin `/info` endpoint intentionally omits MongoDB hostname.
+- Debug mode defaults to `False`; startup validation blocks production launch with debug enabled.
+- `owner_id` consistently stripped from API responses via Pydantic schema exclusion.
+
+#### 10. Git History Review
+
+- No code changes since last review. HEAD at `7d29a54` (previous security review commit only).
+- No secret files accidentally committed.
+- No force pushes, rebases, or reverts detected.
+
+#### 11. Infrastructure & Configuration
+
+- Production safety checks at startup: weak secret key blocked, localhost MongoDB warned, HTTPS enforcement checked.
+- Database safety check prevents non-production hosts from connecting to production MongoDB.
+- Secure defaults: `debug=False`, `cors_origins=[]`, `email_verification_required=True`.
+- Admin panel IP-restricted with explicit allowlist.
+- Systemd services hardened with `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`.
+
+#### 12. Third-Party Integration Security
+
+- Anthropic API key loaded from environment variables with explicit timeouts (60-120 seconds).
+- PostHog API key loaded from secrets config. Analytics disabled by default. EU instance for GDPR compliance.
+- AWS credentials loaded from environment via named profile. Never logged.
+- No webhook endpoints requiring signature validation.
+- No SSRF vectors — no endpoint accepts user-supplied URLs for server-side fetching.
+
+---
+
+## :bar_chart: Summary
+
+| Severity | Count |
+|----------|-------|
+| :red_circle: CRITICAL | 0 |
+| :orange_circle: WARNING | 3 |
+| :yellow_circle: INFO | 39 |
+| :green_circle: CLEAN | 12 categories |
+
+**Date of review:** 2026-07-08
+**Reviewer:** Automated security audit (Claude Code)
+**Codebase version:** 0.7.86 (commit 7d29a54)
+
+### Comparison with Previous Review (2026-07-06)
+
+| Item | 2026-07-06 | 2026-07-08 | Status |
+|------|-----------|-----------|--------|
+| CRITICAL | 0 | 0 | Maintained |
+| WARNING | 0 | 3 | +3 new |
+| INFO | 37 | 39 | +2 new |
+
+### Changes Since Last Review
+
+- No application code changes since last review (HEAD at `7d29a54`, previous security review commit only).
+- All dependency versions unchanged in lockfile.
+- All 37 INFO findings carried forward unchanged.
+- **3 new WARNING findings** (WARN-1 through WARN-3) identified by a deeper owner_id data isolation audit. These are secondary Wine lookups in the transaction export and transaction view code paths that do not include `owner_id` in the query filter. The wine_ids are derived from owner-scoped data, and MongoDB ObjectIds are globally unique, so exploitation requires data corruption. These violate the project's stated security policy.
+- **2 new INFO findings** (INFO-38, INFO-39):
+  - INFO-38: Pillow — 3 new CVEs (CVE-2026-55379, CVE-2026-55380, CVE-2026-55798), none exploitable via WineBox
+  - INFO-39: Six `update_one` calls that don't re-assert owner_id in the filter (defence-in-depth)
+
+### Top 3 Priorities
+
+1. **Fix WARN-1/2/3: Add `owner_id` to Wine lookups in export and transaction views** — These are the only WARNING-level findings and violate the project's own data isolation policy. Simple one-line fixes: add `"owner_id": current_user.id` or `"owner_id": owner_id` to three query filters.
+2. **Batch dependency upgrade (INFO-33, INFO-34, INFO-26, INFO-18, INFO-38)** — cryptography (GHSA-537c-gmf6-5ccf), python-multipart (3 CVEs), PyJWT (5 CVEs), and Pillow (3 CVEs) are the highest-value upgrades. All are straightforward version bumps with no expected breaking changes. This single maintenance session would close 12 CVEs.
+3. **Plan coordinated FastAPI + Starlette upgrade (INFO-8, INFO-35)** — Starlette 0.50.0 now has 4 CVEs (up from 1). While none are exploitable in WineBox, the accumulating count adds urgency. Requires upgrading FastAPI from 0.128.1 to >=0.135.0.


### PR DESCRIPTION
## Summary

Daily security review for 2026-07-08. **3 WARNING findings** identified by a deeper owner_id data isolation audit.

### WARNING findings (3)

- **WARN-1:** `winebox/routers/export.py:250` — Wine lookup in `export_transactions` missing `owner_id` filter
- **WARN-2:** `winebox/services/cellar_event_view.py:179` — Bulk Wine lookup in `list_events_as_transactions` missing `owner_id` filter
- **WARN-3:** `winebox/services/cellar_event_view.py:219` — Single Wine lookup in `get_event_as_transaction` missing `owner_id` filter

All three are secondary lookups where the wine_ids are derived from owner-scoped data. MongoDB ObjectIds are globally unique, so exploitation requires data corruption. However, these violate the project's stated security policy that all user data queries must filter by `owner_id`.

### New INFO findings (2)

- **INFO-38:** Pillow 12.2.0 — 3 new CVEs (CVE-2026-55379, CVE-2026-55380, CVE-2026-55798), none exploitable via WineBox
- **INFO-39:** Six `update_one` calls that don't re-assert owner_id in the filter (defence-in-depth)

### Carried forward

- 37 INFO findings from previous review, unchanged
- No code changes since last review
- All dependency versions unchanged

### Top 3 priorities

1. Fix WARN-1/2/3 — simple one-line fixes to add `owner_id` to three query filters
2. Batch dependency upgrade (cryptography, python-multipart, PyJWT, Pillow) — closes 12 CVEs
3. Plan coordinated FastAPI + Starlette upgrade (4 accumulated CVEs)

Full report: `docs/security-reports/2026-07-08.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTKbdDdHseAP7G7u1c6aRv)_